### PR TITLE
Add scriv to workflow, including checker workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,22 @@
+name: changelog
+on:
+  - pull_request
+
+jobs:
+  check_has_news_in_changelog_dir:
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'no-news-is-good-news') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:  # do a deep fetch to allow merge-base and diff
+          fetch-depth: 0
+      - name: check PR adds a news file
+        run: |
+          news_files="$(git diff --name-only "$(git merge-base origin/main "$GITHUB_SHA")" "$GITHUB_SHA" -- changelog.d/*.md)"
+          if [ -n "$news_files" ]; then
+            echo "Saw new files. changelog.d:"
+            echo "$news_files"
+          else
+            echo "No news files seen"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+<!-- scriv-insert-here -->
 
 ## 0.0.6 (2021-09-20)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,24 @@
 
 First off, thank you so much for taking the time to contribute! :+1:
 
+## Tool Requirements
+
+- `make`
+- `tox`
+
+Install `tox` with `pipx install tox`
+
+### Recommended
+
+- `scriv`
+- `pre-commit`
+- Docker
+
+Install `scriv` and `pre-commit` with
+
+    pipx install scriv
+    pipx install pre-commit
+
 ## Bugs & Feature Requests
 
 Should be reported as

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,12 @@ lint:
 test:
 	tox
 
-.PHONY: showvars release
+.PHONY: showvars prepare-release release
 showvars:
 	@echo "FUNCX_COMMON_VERSION=$(FUNCX_COMMON_VERSION)"
+prepare-release:
+	tox -e prepare-release -- --version "$(FUNCX_COMMON_VERSION)"
+	$(EDITOR) CHANGELOG.md
 release:
 	git tag -s "$(FUNCX_COMMON_VERSION)" -m "v$(FUNCX_COMMON_VERSION)"
 	-git push $(shell git rev-parse --abbrev-ref @{push} | cut -d '/' -f1) refs/tags/$(FUNCX_COMMON_VERSION)

--- a/changelog.d/20211014_215238_sirosen.md
+++ b/changelog.d/20211014_215238_sirosen.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Begin using `scriv` to manage the changelog

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,7 @@
+# Changelog Fragments
+
+Create changelog entries with `scriv`
+
+Use `scriv create --edit` to create a changelog fragment
+
+Fragments are collected for release as part of `make prepare-release`

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,10 +35,14 @@ dev =
     types-redis
 redis = redis>=3.5.3,<4
 
+[scriv]
+format = md
+output_file = CHANGELOG.md
+md_header_level = 2
+entry_title_template = {{ version }} ({{ date.strftime("%%Y-%%m-%%d") }})
 
 [isort]
 profile = black
-
 
 [flake8]
 exclude = .git,.tox,__pycache__,dist,venv,.venv*

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,11 @@ deps = mypy
 extras = dev
 commands = mypy src/
 
+[testenv:prepare-release]
+skip_install = true
+deps = scriv
+commands = scriv collect {posargs}
+
 [testenv:publish-release]
 skip_install = true
 deps = twine


### PR DESCRIPTION
- `scriv create --edit` to add a newsfile
- `scriv collect --version ...` wrapped in `make prepare-release`
- A marker comment in the changelog for insertion of news snippets
- Basic scriv config in `setup.cfg`

The only bit here which gets a little bit gnarly is that we don't have the package version in a source file, so we can't use a scriv `literal:` to parse it automatically from there. Maybe the version should move into there and we should do the read-raw-file tricks in `setup.py`, leaving `setup.cfg` responsible for everything else.