### PR TITLE
Set redis heartbeats, associated cleanup

### DIFF
--- a/changelog.d/20211015_181331_sirosen_improved_connnections.md
+++ b/changelog.d/20211015_181331_sirosen_improved_connnections.md
@@ -1,0 +1,30 @@
+### Removed
+
+- `funcx_common.redis.HasRedisConnection` no longer provides the
+  `log_connection_errors` decorator
+- `funcx_common.redis.FuncxRedisPubSub` and `funcx_common.redis.FuncxEndpointTaskQueue`
+  no longer automatically log redis connection errors to the `funcx_common` logger. Users
+  of these classes should either handle these errors themselves or make use of the new
+  error logging decorator
+
+### Added
+
+- A `funcx_common.redis.HasRedisConnection` object now accepts a
+  `redis_connection_factory` callable which is used to instantiate the `redis.Redis`
+  object, to allow overrides to the connection construction process. The callable
+  must have the signature `(str, int) -> redis.Redis`, and the default
+  is a function visible under the name
+  `funcx_common.redis.default_redis_connection_factory`.
+- A new context-manager is available as a method of the `HasRedisConnection` class,
+  `HasRedisConnection.connection_error_logging`. This can be used to capture
+  and log (at exception-level) redis connection errors to the `funcx_common` logger
+- The default connection construction for `HasRedisConnection` now sets
+  `health_check_interval=30`. To override this setting, use
+  `redis_connection_factory`
+
+### Changed
+
+- The `FuncxRedisConnection` class has been renamed to
+  `HasRedisConnection`. The name change better indicates that this class
+  is not a connection itself -- it's just an inheritable way of constructing
+  a connection.

--- a/src/funcx_common/redis/__init__.py
+++ b/src/funcx_common/redis/__init__.py
@@ -1,4 +1,4 @@
-from .connection import FuncxRedisConnection
+from .connection import HasRedisConnection, default_redis_connection_factory
 from .fields import HasRedisFields, HasRedisFieldsMeta, RedisField
 from .pubsub import FuncxRedisPubSub
 from .serde import (
@@ -13,7 +13,8 @@ from .serde import (
 from .task_queue import FuncxEndpointTaskQueue
 
 __all__ = (
-    "FuncxRedisConnection",
+    "HasRedisConnection",
+    "default_redis_connection_factory",
     "FuncxEndpointTaskQueue",
     "HasRedisFields",
     "HasRedisFieldsMeta",

--- a/src/funcx_common/redis/connection.py
+++ b/src/funcx_common/redis/connection.py
@@ -54,11 +54,11 @@ class HasRedisConnection:
         )
         self.redis_client = redis_connection_factory(hostname, port)
 
-    def _get_str_attrs(self) -> t.List[str]:
-        return [str(self.redis_client)]
+    def _repr_attrs(self) -> t.List[str]:
+        return [repr(self.redis_client)]
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(" + ",".join(self._get_str_attrs()) + ")"
+        return f"{self.__class__.__name__}(" + ",".join(self._repr_attrs()) + ")"
 
     @contextlib.contextmanager
     def connection_error_logging(self) -> t.Iterator[None]:

--- a/src/funcx_common/redis/task_queue.py
+++ b/src/funcx_common/redis/task_queue.py
@@ -2,13 +2,22 @@ import queue
 import typing as t
 
 from ..tasks import TaskProtocol, TaskState
-from .connection import FuncxRedisConnection
+from .connection import _OPT_CONNECTION_FACTORY_T, HasRedisConnection
 
 
-class FuncxEndpointTaskQueue(FuncxRedisConnection):
-    def __init__(self, hostname: str, endpoint: str, *, port: int = 6379):
+class FuncxEndpointTaskQueue(HasRedisConnection):
+    def __init__(
+        self,
+        hostname: str,
+        endpoint: str,
+        *,
+        port: int = 6379,
+        redis_connection_factory: _OPT_CONNECTION_FACTORY_T = None,
+    ):
         self.endpoint = endpoint
-        super().__init__(hostname, port=port)
+        super().__init__(
+            hostname, port=port, redis_connection_factory=redis_connection_factory
+        )
 
     def _get_str_attrs(self) -> t.List[str]:
         return [f"endpoint={self.endpoint}"] + super()._get_str_attrs()
@@ -17,16 +26,14 @@ class FuncxEndpointTaskQueue(FuncxRedisConnection):
     def queue_name(self) -> str:
         return f"task_{self.endpoint}_list"
 
-    @FuncxRedisConnection.log_connection_errors
     def enqueue(self, task: TaskProtocol) -> None:
         task.endpoint = self.endpoint
         task.status = TaskState.WAITING_FOR_EP
         self.redis_client.rpush(self.queue_name, task.task_id)
 
-    @FuncxRedisConnection.log_connection_errors
     def dequeue(self, *, timeout: int = 1) -> str:
         res = self.redis_client.blpop(self.queue_name, timeout=timeout)
         if not res:
             raise queue.Empty
         _queue_name, task_id = res
-        return task_id
+        return t.cast(str, task_id)

--- a/src/funcx_common/redis/task_queue.py
+++ b/src/funcx_common/redis/task_queue.py
@@ -19,8 +19,8 @@ class FuncxEndpointTaskQueue(HasRedisConnection):
             hostname, port=port, redis_connection_factory=redis_connection_factory
         )
 
-    def _get_str_attrs(self) -> t.List[str]:
-        return [f"endpoint={self.endpoint}"] + super()._get_str_attrs()
+    def _repr_attrs(self) -> t.List[str]:
+        return [f"endpoint={self.endpoint}"] + super()._repr_attrs()
 
     @property
     def queue_name(self) -> str:


### PR DESCRIPTION
Full changes are described in the changelog fragment. But in summary:
- cleanup the "has a connection" class and rename it
- set `health_check_interval` on the redis.Redis objects
- carve out a path for altering the redis.Redis object if we need it in the future

On that last point, there's a `default_redis_connection_factory` function, and it can be replaced or wrapped as necessary if some caller *really* needs it.

One of the casualties of the cleanup is the "automatic" error logging, which would only do anything if you setup a logger on `funcx_common` anyway. Just allowing errors to propagate and be handled by the application, with no special logging, is more appropriate to most contexts and doesn't lose us much of anything.

---

@yadudoc, I want to get away from being a "Benevolent Dictator" on funcx-common, since it's going to become an increasingly core/essential part of our software stack. Plus, now that I have `scriv`-changelog stuff setup, it seems a shame not to take advantage of it, and it works best with proper review.

I'm calling you in on this one as the first change for proper review here, but if you want to chat some time to get up to speed on any part of the library, let me know. I'll make sure you have admin on the repo so that I'm not a single-owner (if you don't already have it via org-level permissions).