### PR TITLE
Remove HasRedisConnection and simplify

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,3 +15,4 @@ exclude_lines =
     if __name__ == .__main__.:
     # don't check coverage on type checking conditionals
     if TYPE_CHECKING:
+    if t.TYPE_CHECKING:

--- a/changelog.d/20211022_043900_sirosen_redis_connection_rewrite.md
+++ b/changelog.d/20211022_043900_sirosen_redis_connection_rewrite.md
@@ -1,0 +1,17 @@
+### Removed
+
+- The `HasRedisConnection` class has been removed
+
+### Added
+
+- Redis connections created by `default_redis_connection_factory` now default
+  to loading a redis URL from an environment variable, `FUNCX_COMMON_REDIS_URL`,
+  with a default of `redis://localhost:6379`
+
+### Changed
+
+- The redis logging decorator has been moved. It is no longer attached to a
+  class, but is now available as `funcx_common.redis.redis_connection_error_logging`
+- The signatures for creating `FuncxRedisPubSub` and `FuncxEndpointTaskQueue`
+  have changed. They can now be passed a `redis.Redis` object, and default to
+  calling `default_redis_connection_factory`

--- a/src/funcx_common/redis/__init__.py
+++ b/src/funcx_common/redis/__init__.py
@@ -1,4 +1,4 @@
-from .connection import HasRedisConnection, default_redis_connection_factory
+from .connection import default_redis_connection_factory, redis_connection_error_logging
 from .fields import HasRedisFields, HasRedisFieldsMeta, RedisField
 from .pubsub import FuncxRedisPubSub
 from .serde import (
@@ -13,8 +13,8 @@ from .serde import (
 from .task_queue import FuncxEndpointTaskQueue
 
 __all__ = (
-    "HasRedisConnection",
     "default_redis_connection_factory",
+    "redis_connection_error_logging",
     "FuncxEndpointTaskQueue",
     "HasRedisFields",
     "HasRedisFieldsMeta",

--- a/src/funcx_common/redis/task_queue.py
+++ b/src/funcx_common/redis/task_queue.py
@@ -2,25 +2,24 @@ import queue
 import typing as t
 
 from ..tasks import TaskProtocol, TaskState
-from .connection import _OPT_CONNECTION_FACTORY_T, HasRedisConnection
+from .connection import default_redis_connection_factory
+
+if t.TYPE_CHECKING:
+    import redis
 
 
-class FuncxEndpointTaskQueue(HasRedisConnection):
+class FuncxEndpointTaskQueue:
     def __init__(
-        self,
-        hostname: str,
-        endpoint: str,
-        *,
-        port: int = 6379,
-        redis_connection_factory: _OPT_CONNECTION_FACTORY_T = None,
-    ):
+        self, endpoint: str, *, redis_client: t.Optional["redis.Redis"] = None
+    ) -> None:
+        if redis_client is None:
+            redis_client = default_redis_connection_factory()
+        self.redis_client = redis_client
         self.endpoint = endpoint
-        super().__init__(
-            hostname, port=port, redis_connection_factory=redis_connection_factory
-        )
 
-    def _repr_attrs(self) -> t.List[str]:
-        return [f"endpoint={self.endpoint}"] + super()._repr_attrs()
+    def __repr__(self) -> str:
+        attr_str = f"endpoint={self.endpoint},redis_client={self.redis_client}"
+        return f"FuncxEndpointTaskQueue({attr_str})"
 
     @property
     def queue_name(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _unset_envvar_if_set(monkeypatch):
+    # use monkeypatch.delenv to ensure that the env var is not set, preventing
+    # test behaviors from changing
+    # TODO: allow use of the redis URL env var to control test behavior
+    monkeypatch.delenv("FUNCX_COMMON_REDIS_URL", raising=False)

--- a/tests/functional/redis/test_pubsub.py
+++ b/tests/functional/redis/test_pubsub.py
@@ -19,8 +19,8 @@ class SimpleInMemoryTask(TaskProtocol):
     not LOCAL_REDIS_REACHABLE, reason="test requires local redis reachable"
 )
 def test_put_and_get_single_task():
-    producer = FuncxRedisPubSub("localhost")
-    consumer = FuncxRedisPubSub("localhost")
+    producer = FuncxRedisPubSub()
+    consumer = FuncxRedisPubSub()
     t = SimpleInMemoryTask()
     epid = str(uuid.uuid1())
 
@@ -39,8 +39,8 @@ def test_put_and_get_single_task():
 def test_put_and_get_single_task_deferred():
     # same as above, but do the subscribe call after pushing the task into the
     # queue
-    producer = FuncxRedisPubSub("localhost")
-    consumer = FuncxRedisPubSub("localhost")
+    producer = FuncxRedisPubSub()
+    consumer = FuncxRedisPubSub()
     t = SimpleInMemoryTask()
     epid = str(uuid.uuid1())
 
@@ -56,7 +56,7 @@ def test_put_and_get_single_task_deferred():
     not LOCAL_REDIS_REACHABLE, reason="test requires local redis reachable"
 )
 def test_empty_get():
-    consumer = FuncxRedisPubSub("localhost")
+    consumer = FuncxRedisPubSub()
     epid = str(uuid.uuid1())
 
     consumer.subscribe(epid)
@@ -68,7 +68,7 @@ def test_empty_get():
     not LOCAL_REDIS_REACHABLE, reason="test requires local redis reachable"
 )
 def test_subscribed_status():
-    consumer = FuncxRedisPubSub("localhost")
+    consumer = FuncxRedisPubSub()
     epid = str(uuid.uuid1())
 
     assert not consumer.subscribed
@@ -90,8 +90,8 @@ def test_unsubscribe_and_resubscribe():
     # subscribe, get a task, unsubscribe, task is not gotten, resubscribe and
     # get again
 
-    producer = FuncxRedisPubSub("localhost")
-    consumer = FuncxRedisPubSub("localhost")
+    producer = FuncxRedisPubSub()
+    consumer = FuncxRedisPubSub()
     t1 = SimpleInMemoryTask()
     t2 = SimpleInMemoryTask()
     epid = str(uuid.uuid1())
@@ -131,7 +131,7 @@ def test_unsubscribe_and_resubscribe():
 def test_final_messages_without_unsub():
     # getting final messages without unsubscribing is an error, as it means
     # that get_final_messages would never terminate
-    consumer = FuncxRedisPubSub("localhost")
+    consumer = FuncxRedisPubSub()
     epid = str(uuid.uuid1())
     consumer.subscribe(epid)
 

--- a/tests/functional/redis/test_task_queue.py
+++ b/tests/functional/redis/test_task_queue.py
@@ -20,7 +20,7 @@ def test_enqueue_and_dequeue_simple_task():
 
     mytask = SimpleInMemoryTask()
     endpoint = str(uuid.uuid1())
-    task_queue = FuncxEndpointTaskQueue("localhost", endpoint)
+    task_queue = FuncxEndpointTaskQueue(endpoint)
 
     assert mytask.endpoint is None
 
@@ -39,7 +39,7 @@ def test_enqueue_and_dequeue_simple_task():
 )
 def test_dequeue_empty_behavior():
     endpoint = str(uuid.uuid1())
-    task_queue = FuncxEndpointTaskQueue("localhost", endpoint)
+    task_queue = FuncxEndpointTaskQueue(endpoint)
 
     with pytest.raises(queue.Empty):
         task_queue.dequeue()


### PR DESCRIPTION
HasRedisConnection is replaced entirely by use of `default_redis_connection_factory` with a default URL loaded from an env var.

The pubsub and task queue objects now accept an optional redis.Redis object each, and do not take hostname and port.

This simplifies things, solves any naming problem (because the badly named component is now gone), and still allows custom connection objects to be passed to the pubsub and task queue.