### PR TITLE
Add TaskStorage abstraction for writing task results to various systems (S3 and Redis)

### DIFF
--- a/src/funcx_common/task_storage/__init__.py
+++ b/src/funcx_common/task_storage/__init__.py
@@ -1,9 +1,10 @@
-from .base import TaskStorage
+from .base import NullTaskStorage, TaskStorage
 from .chain import ChainedTaskStorage
 from .memory import MemoryTaskStorage, ThresholdedMemoryTaskStorage
 
 __all__ = (
     "TaskStorage",
+    "NullTaskStorage",
     "ChainedTaskStorage",
     "MemoryTaskStorage",
     "ThresholdedMemoryTaskStorage",

--- a/src/funcx_common/task_storage/__init__.py
+++ b/src/funcx_common/task_storage/__init__.py
@@ -1,0 +1,10 @@
+from .base import TaskStorage
+from .chain import ChainedTaskStorage
+from .memory import MemoryTaskStorage, ThresholdedMemoryTaskStorage
+
+__all__ = (
+    "TaskStorage",
+    "ChainedTaskStorage",
+    "MemoryTaskStorage",
+    "ThresholdedMemoryTaskStorage",
+)

--- a/src/funcx_common/task_storage/base.py
+++ b/src/funcx_common/task_storage/base.py
@@ -1,0 +1,27 @@
+import abc
+import typing as t
+
+from ..tasks import TaskProtocol
+
+
+class TaskStorage(abc.ABC):
+    """
+    Abstract class which defines the interface for task storage.
+    """
+
+    @abc.abstractmethod
+    def store_result(self, task: TaskProtocol, result: str) -> bool:
+        """
+        Store the result of a task.
+
+        If the storage call succeeded, this MUST return True.
+        If the storage call failed, an error may be raised or this may return False.
+        """
+
+    @abc.abstractmethod
+    def get_result(self, task: TaskProtocol) -> t.Optional[str]:
+        """
+        Get the result of a task.
+
+        Returns a string if a result was found, and None otherwise.
+        """

--- a/src/funcx_common/task_storage/base.py
+++ b/src/funcx_common/task_storage/base.py
@@ -14,8 +14,13 @@ class TaskStorage(abc.ABC):
         """
         Store the result of a task.
 
-        If the storage call succeeded, this MUST return True.
-        If the storage call failed, an error may be raised or this may return False.
+        If the storage call succeeded, this returns True.
+        If the storage call was rejected, this returns False.
+        If the call failed, and exception should be raised.
+
+        TaskStorage objects may reject calls without failing. For example, if the
+        storage system is a cache of limited size, filling the cache will lead to
+        rejected storage.
         """
 
     @abc.abstractmethod
@@ -25,3 +30,15 @@ class TaskStorage(abc.ABC):
 
         Returns a string if a result was found, and None otherwise.
         """
+
+
+class NullTaskStorage(TaskStorage):
+    """
+    A TaskStorage which rejects all data and cannot hold data.
+    """
+
+    def store_result(self, task: TaskProtocol, result: str) -> bool:
+        return False
+
+    def get_result(self, task: TaskProtocol) -> t.Optional[str]:
+        return None

--- a/src/funcx_common/task_storage/chain.py
+++ b/src/funcx_common/task_storage/chain.py
@@ -18,6 +18,9 @@ class ChainedTaskStorage(TaskStorage):
     In this scenario, the fast storage will be tried first for both the store and get
     operations.
 
+    If the fast storage rejects a storage operation, the slow storage will be tried. A
+    failure (exception) would be raised immediately, however.
+
     The assumption here is that the fast storage responds quickly enough that it can be
     checked first in all cases, even without additional context for the call.
     """

--- a/src/funcx_common/task_storage/chain.py
+++ b/src/funcx_common/task_storage/chain.py
@@ -1,0 +1,39 @@
+import typing as t
+
+from ..tasks import TaskProtocol
+from .base import TaskStorage
+
+
+class ChainedTaskStorage(TaskStorage):
+    """
+    Chained storage combines multiple other concrete storage options.
+
+    The storage methods are used on a "first-come, first-served" basis, with the
+    intended usage pattern being
+
+    >>> slow_storage = ...
+    >>> fast_storage = ...
+    >>> task_storage = ChainedTaskStorage(fast_storage, slow_storage)
+
+    In this scenario, the fast storage will be tried first for both the store and get
+    operations.
+
+    The assumption here is that the fast storage responds quickly enough that it can be
+    checked first in all cases, even without additional context for the call.
+    """
+
+    def __init__(self, *storages: TaskStorage) -> None:
+        self._storages = list(storages)
+
+    def store_result(self, task: TaskProtocol, result: str) -> bool:
+        for store in self._storages:
+            if store.store_result(task, result):
+                return True
+        return False
+
+    def get_result(self, task: TaskProtocol) -> t.Optional[str]:
+        for store in self._storages:
+            res = store.get_result(task)
+            if res is not None:
+                return res
+        return None

--- a/src/funcx_common/task_storage/memory.py
+++ b/src/funcx_common/task_storage/memory.py
@@ -1,0 +1,48 @@
+import typing as t
+
+from ..tasks import TaskProtocol
+from .base import TaskStorage
+
+
+class MemoryTaskStorage(TaskStorage):
+    """
+    The simplest possible task storage system: an in-memory dictionary.
+
+    This is meant to
+    - demonstrate a complete implementation of the TaskStorage interface
+    - be usable in testsuites or other contexts which want an in-process storage system
+    """
+
+    def __init__(self) -> None:
+        self._results: t.Dict[str, str] = {}
+
+    def store_result(self, task: TaskProtocol, result: str) -> bool:
+        self._results[task.task_id] = result
+        return True
+
+    def get_result(self, task: TaskProtocol) -> t.Optional[str]:
+        return self._results.get(task.task_id)
+
+
+class ThresholdedMemoryTaskStorage(MemoryTaskStorage):
+    """
+    ThresholdedMemoryTaskStorage must be constructed with a size limit.
+    If the length of a result exceeds the limit, it will be rejected from the store
+    operation.
+
+    Otherwise, it is the same as MemoryTaskStorage.
+
+    Note that the result limit is given in number of characters, not bytes. TaskStorage
+    handles strings, and we don't want to do any extra encode/decode passes.
+    """
+
+    def __init__(self, result_limit_chars: int = 100) -> None:
+        self._result_limit_chars = result_limit_chars
+        super().__init__()
+
+    def store_result(self, task: TaskProtocol, result: str) -> bool:
+        if len(result) > self._result_limit_chars:
+            return False
+
+        self._results[task.task_id] = result
+        return True

--- a/src/funcx_common/task_storage/memory.py
+++ b/src/funcx_common/task_storage/memory.py
@@ -6,7 +6,7 @@ from .base import TaskStorage
 
 class MemoryTaskStorage(TaskStorage):
     """
-    The simplest possible task storage system: an in-memory dictionary.
+    The simplest usable task storage system: an in-memory dictionary.
 
     This is meant to
     - demonstrate a complete implementation of the TaskStorage interface
@@ -36,7 +36,7 @@ class ThresholdedMemoryTaskStorage(MemoryTaskStorage):
     handles strings, and we don't want to do any extra encode/decode passes.
     """
 
-    def __init__(self, result_limit_chars: int = 100) -> None:
+    def __init__(self, *, result_limit_chars: int = 100) -> None:
         self._result_limit_chars = result_limit_chars
         super().__init__()
 

--- a/tests/unit/test_task_storage.py
+++ b/tests/unit/test_task_storage.py
@@ -1,0 +1,101 @@
+import uuid
+
+from funcx_common.task_storage import (
+    ChainedTaskStorage,
+    MemoryTaskStorage,
+    NullTaskStorage,
+    ThresholdedMemoryTaskStorage,
+)
+from funcx_common.tasks import TaskProtocol, TaskState
+
+
+class SimpleInMemoryTask(TaskProtocol):
+    def __init__(self):
+        self.task_id = str(uuid.uuid1())
+        self.endpoint = None
+        self.status = TaskState.RECEIVED
+
+
+def test_memory_storage_simple():
+    memstore = MemoryTaskStorage()
+    result = "foo result"
+    task = SimpleInMemoryTask()
+
+    b = memstore.store_result(task, result)
+    assert b is True
+    assert memstore.get_result(task) == result
+
+
+def test_chained_storage_first_success():
+    memstore1 = MemoryTaskStorage()
+    memstore2 = MemoryTaskStorage()
+
+    chain = ChainedTaskStorage(memstore1, memstore2)
+
+    result = "foo result"
+    task = SimpleInMemoryTask()
+
+    b = chain.store_result(task, result)
+    assert b is True
+    assert memstore2.get_result(task) is None
+    assert memstore1.get_result(task) == result
+    assert chain.get_result(task) == result
+
+
+def test_thresholded_storage_limit():
+    store = ThresholdedMemoryTaskStorage(result_limit_chars=10)
+
+    result = "result"
+    task = SimpleInMemoryTask()
+
+    b = store.store_result(task, result)
+    assert b is True
+    assert store.get_result(task) == result
+
+    result2 = "result too long for char limit"
+    task2 = SimpleInMemoryTask()
+
+    b = store.store_result(task2, result2)
+    assert b is False
+    assert store.get_result(task2) is None
+
+
+def test_chained_with_threshold():
+    memstore1 = ThresholdedMemoryTaskStorage(result_limit_chars=3)
+    memstore2 = MemoryTaskStorage()
+
+    chain = ChainedTaskStorage(memstore1, memstore2)
+
+    result = "foo result"
+    task = SimpleInMemoryTask()
+
+    b = chain.store_result(task, result)
+    assert b is True
+    assert memstore1.get_result(task) is None
+    assert memstore2.get_result(task) == result
+    assert chain.get_result(task) == result
+
+
+def test_null_storage():
+    store = NullTaskStorage()
+
+    result = "result"
+    task = SimpleInMemoryTask()
+
+    b = store.store_result(task, result)
+    assert b is False
+    assert store.get_result(task) is None
+
+
+def test_failing_chain_storage():
+    store1 = NullTaskStorage()
+    store2 = NullTaskStorage()
+
+    chain = ChainedTaskStorage(store1, store2)
+
+    result = "result"
+    task = SimpleInMemoryTask()
+
+    b = chain.store_result(task, result)
+    assert b is False
+    assert chain.get_result(task) is None


### PR DESCRIPTION
This is the interface we'll have for combining storage systems to hold task results. Valid backing stores will be S3 and Redis.
At present, since there are no really useful concrete storage adapters defined (unless you count the memory one), this is open as a draft.