### PR TITLE
Update contrib and release notes for scriv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,3 +62,16 @@ These are recommendations for contributors:
 
   - Include tests for any new or changed functionality
   - Use type annotations liberally
+
+## Adding Changelog Fragments
+
+Any change to the codebase must either include a changelog fragment (in some
+projects these are called "newsfiles") or be in a PR labeled as
+`no-news-is-good-news`.
+
+To create a new changelog fragment, run
+
+    scriv create --edit
+
+and populate the fragment. It will include comments which instruct you on how
+to fill out the fragment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ These are recommendations for contributors:
 ## Adding Changelog Fragments
 
 Any change to the codebase must either include a changelog fragment (in some
-projects these are called "newsfiles") or be in a PR labeled as
+projects these are called "newsfiles") or be in a GitHub PR with the label
 `no-news-is-good-news`.
 
 To create a new changelog fragment, run

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,7 @@
 # Releasing a funcx-common Version
 
-1. Bump version in `setup.cfg` and update changelog with version and date
-2. Commit: `git commit -m 'Bump version and changelog for release'`
-3. Tag and publish release: `make release`
-4. Write up the release as a [funcx-common GitHub Release](https://github.com/funcx-faas/funcx-common/releases)
+1. Bump version in `setup.cfg`
+2. Update changelog: `make prepare-release`
+3. Commit: `git commit -m 'Bump version and changelog for release'`
+4. Tag and publish release: `make release`
+5. Write up the release as a [funcx-common GitHub Release](https://github.com/funcx-faas/funcx-common/releases)


### PR DESCRIPTION
With the addition of the scriv toolchain for managing changelog fragments, both the contrib and releasing docs needed updating.