### PR TITLE
Implement first draft of "messagepack" v0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,4 +37,4 @@ jobs:
         if: matrix.python-version == '3.9'
         run: python -m tox -e lint,mypy
       - name: test
-        run: python -m tox -e py,py-nodeps -- --cov-report="term-missing:skip-covered"
+        run: python -m tox -e py,py-nodeps,py-withendpoint -- --cov-report="term-missing:skip-covered"

--- a/changelog.d/20211111_193931_sirosen_messagepack.md
+++ b/changelog.d/20211111_193931_sirosen_messagepack.md
@@ -1,0 +1,11 @@
+### Added
+
+- A new subpackage, `funcx_common.messagepack` provides an implementation of
+  serialization and deserialization of message objects meant to be compatible
+  with `funcx_endpoint.executors.high_throughput.messages` in its on-the-wire
+  representation of messages. Changes between the two implementations are
+  noted in a README for `messagepack`.
+  - `messagepack` defines protocol versions, starting with the current and
+    unversioned v0, for handling changes to the protocol over time
+  - only v0 is implemented, but a suggested plan for v1 of the protocol can be
+    seen in the `messagepack` readme

--- a/src/funcx_common/messagepack/README.md
+++ b/src/funcx_common/messagepack/README.md
@@ -64,21 +64,6 @@ detailed here.
 ### Messages do not pack themselves
 
 Under `funcx-endpoint`, messages are objects providing implementations of
-`pack()` and `unpack()` as a method and classmethod.  and `funcx-endpoint`
-"messages"
-
-messagepack is based off of message definitions provided by `funcx-endpoint`
-and is meant to be fully interchangeable.
-
-The on-the-wire format for v0 of the protocol is an exact match for the
-wire-format provided by the `funcx-endpoint` messages.
-
-However, the python objects provided by this module have some key differences,
-detailed here.
-
-### Messages do not pack themselves
-
-Under `funcx-endpoint`, messages are objects providing implementations of
 `pack()` and `unpack()` as a method and classmethod. In order to have protocol
 version dispatch handled by a central source, and to disentangle common and
 message-specific details, this is no longer the case.

--- a/src/funcx_common/messagepack/README.md
+++ b/src/funcx_common/messagepack/README.md
@@ -1,0 +1,111 @@
+# messagepack
+
+This subpackage defines a message passing protocol for funcx endpoints and the
+forwarder to exchange information, called "messagepack".
+
+Today, only the v0 implementation of the protocol exists, but under wrappers
+which, in theory, could be used to support future protocol versions.
+
+## Protocol Support, send and receive
+
+Message sending specifies a protocol version defaulting to the lowest supported
+version of the protocol in use. This ensures a broad range of compatibility
+with readers of the messages.
+
+When receiving a message, the first step is always to attempt to determine the
+protocol version.
+
+## Version Detection (v0 vs other versions)
+
+In v0 of the protocol, messages are packed bytes with no header, wrapper, or
+other version information.
+
+Under future versions, an explicit protocol version field will be added.
+
+As a result, the detection logic, until the removal of v0, will be as follows:
+- Attempt to detect a protocol_version
+- If detection fails, protocol_version=0
+- Otherwise, protocol_version=<detected>
+
+## Proposed Protocol Version 1
+
+This section defines a proposal for Version 1 of the messagepack protocol.
+
+v1 of the protocol does the following:
+- messages are encoded as JSON objects
+- the "protocol_version" field of the objects is always `1` (as an int)
+- there is a "message_type" field which contains a string of the message type
+
+For example, under protocol v1, a heartbeat request message can be formulated as
+
+    {"protocol_version": 1, "message_type": "HEARTBEAT_REQ"}
+
+A Task message can be formulated as
+
+    {
+        "protocol_version": 1,
+        "message_type": "TASK",
+        "task_id": task_id,
+        "container_id": container_id,
+        "task_buffer": task_buffer
+    }
+
+## Differences between messagepack and `funcx-endpoint` "messages"
+
+messagepack is based off of message definitions provided by `funcx-endpoint`
+and is meant to be fully interchangeable.
+
+The on-the-wire format for v0 of the protocol is an exact match for the
+wire-format provided by the `funcx-endpoint` messages.
+
+However, the python objects provided by this module have some key differences,
+detailed here.
+
+### Messages do not pack themselves
+
+Under `funcx-endpoint`, messages are objects providing implementations of
+`pack()` and `unpack()` as a method and classmethod.  and `funcx-endpoint`
+"messages"
+
+messagepack is based off of message definitions provided by `funcx-endpoint`
+and is meant to be fully interchangeable.
+
+The on-the-wire format for v0 of the protocol is an exact match for the
+wire-format provided by the `funcx-endpoint` messages.
+
+However, the python objects provided by this module have some key differences,
+detailed here.
+
+### Messages do not pack themselves
+
+Under `funcx-endpoint`, messages are objects providing implementations of
+`pack()` and `unpack()` as a method and classmethod. In order to have protocol
+version dispatch handled by a central source, and to disentangle common and
+message-specific details, this is no longer the case.
+
+Instead, a `MessagePacker` object is used to pack and unpack messages. i.e.
+
+`funcx-endpoint` messages:
+
+    Task().pack()
+
+`funcx-common` messagepack:
+
+    MessagePacker().pack(Task())
+
+On the unpacking side, the `MessagePacker` can `unpack(buf: bytes)`. This
+solves the multiple-dispatch between types (an enum) and classes in a cleaner
+way.
+
+However, each message must provide its own v0 implementation, as these vary too
+much to be implemented by the protocol object in a unified way.
+
+### Message attribute and method changes
+
+Several message attributes have changed. This is a list of all changes.
+
+- `Message.type` is now `Message.message_type` to avoid using a soft-keyword
+- `payload` and `header` are no longer provided properties of `Message` objects
+- `Task` does not define a method `set_local_container`
+- `Task.task_buffer` is always a string, even after loading (in `funcx-endpoint`
+  it is defined as a `str` and then assigned a `bytes` value)

--- a/src/funcx_common/messagepack/__init__.py
+++ b/src/funcx_common/messagepack/__init__.py
@@ -1,6 +1,12 @@
 from .common import Message, MessageType
-from .exceptions import UnrecognizedMessageTypeError
-from .message_types import HeartbeatReq, Task
+from .exceptions import InvalidMessagePayloadError, UnrecognizedMessageTypeError
+from .message_types import (
+    EPStatusReport,
+    Heartbeat,
+    HeartbeatReq,
+    ManagerStatusReport,
+    Task,
+)
 from .packer import MessagePacker
 
 __all__ = (
@@ -10,8 +16,12 @@ __all__ = (
     "Message",
     "MessageType",
     # message types
-    "Task",
+    "EPStatusReport",
+    "Heartbeat",
     "HeartbeatReq",
+    "ManagerStatusReport",
+    "Task",
     # errors
+    "InvalidMessagePayloadError",
     "UnrecognizedMessageTypeError",
 )

--- a/src/funcx_common/messagepack/__init__.py
+++ b/src/funcx_common/messagepack/__init__.py
@@ -1,5 +1,9 @@
 from .common import Message, MessageType
-from .exceptions import InvalidMessagePayloadError, UnrecognizedMessageTypeError
+from .exceptions import (
+    InvalidMessageError,
+    InvalidMessagePayloadError,
+    UnrecognizedMessageTypeError,
+)
 from .packer import MessagePacker
 
 __all__ = (
@@ -9,6 +13,7 @@ __all__ = (
     "Message",
     "MessageType",
     # errors
+    "InvalidMessageError",
     "InvalidMessagePayloadError",
     "UnrecognizedMessageTypeError",
 )

--- a/src/funcx_common/messagepack/__init__.py
+++ b/src/funcx_common/messagepack/__init__.py
@@ -1,12 +1,5 @@
 from .common import Message, MessageType
 from .exceptions import InvalidMessagePayloadError, UnrecognizedMessageTypeError
-from .message_types import (
-    EPStatusReport,
-    Heartbeat,
-    HeartbeatReq,
-    ManagerStatusReport,
-    Task,
-)
 from .packer import MessagePacker
 
 __all__ = (
@@ -15,12 +8,6 @@ __all__ = (
     # common data
     "Message",
     "MessageType",
-    # message types
-    "EPStatusReport",
-    "Heartbeat",
-    "HeartbeatReq",
-    "ManagerStatusReport",
-    "Task",
     # errors
     "InvalidMessagePayloadError",
     "UnrecognizedMessageTypeError",

--- a/src/funcx_common/messagepack/__init__.py
+++ b/src/funcx_common/messagepack/__init__.py
@@ -1,0 +1,17 @@
+from .common import Message, MessageType
+from .exceptions import UnrecognizedMessageTypeError
+from .message_types import HeartbeatReq, Task
+from .packer import MessagePacker
+
+__all__ = (
+    # main packing/unpacking interface
+    "MessagePacker",
+    # common data
+    "Message",
+    "MessageType",
+    # message types
+    "Task",
+    "HeartbeatReq",
+    # errors
+    "UnrecognizedMessageTypeError",
+)

--- a/src/funcx_common/messagepack/common.py
+++ b/src/funcx_common/messagepack/common.py
@@ -1,0 +1,36 @@
+import abc
+import enum
+import typing as t
+
+
+class MessageType(enum.Enum):
+    HEARTBEAT_REQ = 1
+    HEARTBEAT = 2
+    EP_STATUS_REPORT = 3
+    MANAGER_STATUS_REPORT = 4
+    TASK = 5
+    RESULTS_ACK = 6
+
+
+class Message(abc.ABC):
+    message_type: t.ClassVar[MessageType]
+
+    @abc.abstractmethod
+    def get_v0_body(self) -> bytes:
+        """
+        Under v0 of the messagepack protocol, each message type must define its own
+        payload body.
+
+        This is because the method by which a body is encoded and parsed varies by
+        message type.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    @abc.abstractmethod
+    def load_v0_body(cls, buf: bytes) -> "Message":
+        """
+        Under v0 of the messagepack protocol, each message type must define its own
+        payload body parsing. The reason is the same as the existence of `get_v0_body`
+        """
+        raise NotImplementedError()

--- a/src/funcx_common/messagepack/exceptions.py
+++ b/src/funcx_common/messagepack/exceptions.py
@@ -1,0 +1,5 @@
+class UnrecognizedMessageTypeError(ValueError):
+    """
+    An error raised when packing or unpacking a message of a type unknown to the
+    messagepack protocol.
+    """

--- a/src/funcx_common/messagepack/exceptions.py
+++ b/src/funcx_common/messagepack/exceptions.py
@@ -1,11 +1,21 @@
-class UnrecognizedMessageTypeError(ValueError):
+class InvalidMessageError(ValueError):
+    """
+    Message contents did not pass validation checks.
+
+    This can be raised during unpacking OR when creating a new message.
+    """
+
+
+class UnrecognizedMessageTypeError(InvalidMessageError):
     """
     An error raised when packing or unpacking a message of a type unknown to the
     messagepack protocol.
     """
 
 
-class InvalidMessagePayloadError(ValueError):
+class InvalidMessagePayloadError(InvalidMessageError):
     """
     When attempting to unpack a message, an invalid payload was encountered.
+
+    It was not even possible to start message construction with the payload.
     """

--- a/src/funcx_common/messagepack/exceptions.py
+++ b/src/funcx_common/messagepack/exceptions.py
@@ -3,3 +3,9 @@ class UnrecognizedMessageTypeError(ValueError):
     An error raised when packing or unpacking a message of a type unknown to the
     messagepack protocol.
     """
+
+
+class InvalidMessagePayloadError(ValueError):
+    """
+    When attempting to unpack a message, an invalid payload was encountered.
+    """

--- a/src/funcx_common/messagepack/message_types/__init__.py
+++ b/src/funcx_common/messagepack/message_types/__init__.py
@@ -5,14 +5,16 @@ from .ep_status_report import EPStatusReport
 from .heartbeat import Heartbeat
 from .heartbeat_req import HeartbeatReq
 from .manager_status_report import ManagerStatusReport
+from .results_ack import ResultsAck
 from .task import Task
 
-ALL_MESSAGE_TYPES: t.Set[t.Type[Message]] = {
+ALL_MESSAGE_CLASSES: t.Set[t.Type[Message]] = {
     EPStatusReport,
     Heartbeat,
     HeartbeatReq,
     ManagerStatusReport,
     Task,
+    ResultsAck,
 }
 
 __all__ = (
@@ -21,5 +23,6 @@ __all__ = (
     "HeartbeatReq",
     "ManagerStatusReport",
     "Task",
-    "ALL_MESSAGE_TYPES",
+    "ResultsAck",
+    "ALL_MESSAGE_CLASSES",
 )

--- a/src/funcx_common/messagepack/message_types/__init__.py
+++ b/src/funcx_common/messagepack/message_types/__init__.py
@@ -1,7 +1,25 @@
+import typing as t
+
+from ..common import Message
+from .ep_status_report import EPStatusReport
+from .heartbeat import Heartbeat
 from .heartbeat_req import HeartbeatReq
+from .manager_status_report import ManagerStatusReport
 from .task import Task
 
+ALL_MESSAGE_TYPES: t.Set[t.Type[Message]] = {
+    EPStatusReport,
+    Heartbeat,
+    HeartbeatReq,
+    ManagerStatusReport,
+    Task,
+}
+
 __all__ = (
-    "Task",
+    "EPStatusReport",
+    "Heartbeat",
     "HeartbeatReq",
+    "ManagerStatusReport",
+    "Task",
+    "ALL_MESSAGE_TYPES",
 )

--- a/src/funcx_common/messagepack/message_types/__init__.py
+++ b/src/funcx_common/messagepack/message_types/__init__.py
@@ -1,0 +1,7 @@
+from .heartbeat_req import HeartbeatReq
+from .task import Task
+
+__all__ = (
+    "Task",
+    "HeartbeatReq",
+)

--- a/src/funcx_common/messagepack/message_types/ep_status_report.py
+++ b/src/funcx_common/messagepack/message_types/ep_status_report.py
@@ -3,7 +3,7 @@ import typing as t
 import uuid
 
 from ..common import Message, MessageType
-from ..exceptions import InvalidMessagePayloadError
+from ..exceptions import InvalidMessageError, InvalidMessagePayloadError
 
 
 class EPStatusReport(Message):
@@ -21,6 +21,11 @@ class EPStatusReport(Message):
         ep_status_report: t.Dict[str, t.Any],
         task_statuses: t.Dict[str, t.Any],
     ) -> None:
+        if not (isinstance(ep_status_report, dict) and isinstance(task_statuses, dict)):
+            raise InvalidMessageError(
+                "EPStatusReport inner json data was improperly shaped"
+            )
+
         self.endpoint_id = endpoint_id
         self.ep_status = ep_status_report
         self.task_statuses = task_statuses
@@ -69,9 +74,4 @@ class EPStatusReport(Message):
             )
 
         ep_status, task_statuses = loaded_json
-        if not (isinstance(ep_status, dict) and isinstance(task_statuses, dict)):
-            raise InvalidMessagePayloadError(
-                "EPStatusReport inner json data was improperly shaped"
-            )
-
         return cls(endpoint_id, ep_status, task_statuses)

--- a/src/funcx_common/messagepack/message_types/ep_status_report.py
+++ b/src/funcx_common/messagepack/message_types/ep_status_report.py
@@ -1,0 +1,77 @@
+import json
+import typing as t
+import uuid
+
+from ..common import Message, MessageType
+from ..exceptions import InvalidMessagePayloadError
+
+
+class EPStatusReport(Message):
+    """
+    Status report for an endpoint, sent from Endpoint to Forwarder.
+
+    Includes EP-wide info such as utilization, as well as per-task status information.
+    """
+
+    message_type = MessageType.EP_STATUS_REPORT
+
+    def __init__(
+        self,
+        endpoint_id: str,
+        ep_status_report: t.Dict[str, t.Any],
+        task_statuses: t.Dict[str, t.Any],
+    ) -> None:
+        self.endpoint_id = endpoint_id
+        self.ep_status = ep_status_report
+        self.task_statuses = task_statuses
+
+    @property
+    def endpoint_id_bytes(self) -> bytes:
+        return uuid.UUID(self.endpoint_id).bytes
+
+    def get_v0_body(self) -> bytes:
+        # NOTE: it's important that this is done as a dumps(...).encode("ascii")
+        # rather than the more normal "dumps(..., ensure_ascii=True)"
+        # the reason is that this is the method of encoding used in `funcx-endpoint` and
+        # we must be sure that
+        # 1. messages written by this module can be read there
+        # 2. messages written by that module can be read here
+        #
+        # (1) is ensured by this method of encoding in this function
+        # (2) is ensured by testing that `load_v0_body` is an inverse for this method
+        jsonified = json.dumps(
+            [self.ep_status, self.task_statuses],
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("ascii")
+        return self.endpoint_id_bytes + jsonified
+
+    @classmethod
+    def load_v0_body(cls, buf: bytes) -> "EPStatusReport":
+        if len(buf) <= 16:
+            raise InvalidMessagePayloadError("EPStatusReport body was too short")
+
+        # this cannot fail because any 16-byte sequence can be converted to a UUID
+        endpoint_id = str(uuid.UUID(bytes=buf[:16]))
+
+        buf = buf[16:]
+        jsonified = buf.decode("ascii")
+        try:
+            loaded_json = json.loads(jsonified)
+        except ValueError as e:
+            raise InvalidMessagePayloadError(
+                "EPStatusReport body did not contain JSON section"
+            ) from e
+
+        if not (isinstance(loaded_json, list) and len(loaded_json) == 2):
+            raise InvalidMessagePayloadError(
+                "EPStatusReport json data was improperly shaped"
+            )
+
+        ep_status, task_statuses = loaded_json
+        if not (isinstance(ep_status, dict) and isinstance(task_statuses, dict)):
+            raise InvalidMessagePayloadError(
+                "EPStatusReport inner json data was improperly shaped"
+            )
+
+        return cls(endpoint_id, ep_status, task_statuses)

--- a/src/funcx_common/messagepack/message_types/heartbeat.py
+++ b/src/funcx_common/messagepack/message_types/heartbeat.py
@@ -1,0 +1,30 @@
+import uuid
+
+from ..common import Message, MessageType
+from ..exceptions import InvalidMessagePayloadError
+
+
+class Heartbeat(Message):
+    """
+    Generic Heartbeat message, sent in both directions between Forwarder and
+    Endpoint.
+    """
+
+    message_type = MessageType.HEARTBEAT
+
+    def __init__(self, endpoint_id: str) -> None:
+        self.endpoint_id: str = endpoint_id
+
+    def get_v0_body(self) -> bytes:
+        return self.endpoint_id.encode("ascii")
+
+    @classmethod
+    def load_v0_body(cls, buf: bytes) -> "Heartbeat":
+        data = buf.decode("ascii")
+        try:
+            uuid.UUID(data)
+        except ValueError as e:
+            raise InvalidMessagePayloadError(
+                "Heartbeat data does not appear to be a UUID"
+            ) from e
+        return cls(data)

--- a/src/funcx_common/messagepack/message_types/heartbeat.py
+++ b/src/funcx_common/messagepack/message_types/heartbeat.py
@@ -1,7 +1,7 @@
 import uuid
 
 from ..common import Message, MessageType
-from ..exceptions import InvalidMessagePayloadError
+from ..exceptions import InvalidMessageError
 
 
 class Heartbeat(Message):
@@ -13,6 +13,12 @@ class Heartbeat(Message):
     message_type = MessageType.HEARTBEAT
 
     def __init__(self, endpoint_id: str) -> None:
+        try:
+            uuid.UUID(endpoint_id)
+        except ValueError as e:
+            raise InvalidMessageError(
+                "Heartbeat data does not appear to be a UUID"
+            ) from e
         self.endpoint_id: str = endpoint_id
 
     def get_v0_body(self) -> bytes:
@@ -21,10 +27,4 @@ class Heartbeat(Message):
     @classmethod
     def load_v0_body(cls, buf: bytes) -> "Heartbeat":
         data = buf.decode("ascii")
-        try:
-            uuid.UUID(data)
-        except ValueError as e:
-            raise InvalidMessagePayloadError(
-                "Heartbeat data does not appear to be a UUID"
-            ) from e
         return cls(data)

--- a/src/funcx_common/messagepack/message_types/heartbeat_req.py
+++ b/src/funcx_common/messagepack/message_types/heartbeat_req.py
@@ -1,0 +1,12 @@
+from ..common import Message, MessageType
+
+
+class HeartbeatReq(Message):
+    message_type = MessageType.HEARTBEAT_REQ
+
+    def get_v0_body(self) -> bytes:
+        return b""
+
+    @classmethod
+    def load_v0_body(cls, buf: bytes) -> "HeartbeatReq":
+        return cls()

--- a/src/funcx_common/messagepack/message_types/manager_status_report.py
+++ b/src/funcx_common/messagepack/message_types/manager_status_report.py
@@ -1,0 +1,48 @@
+import json
+import typing as t
+
+from ..common import Message, MessageType
+from ..exceptions import InvalidMessagePayloadError
+
+
+class ManagerStatusReport(Message):
+    """
+    Status report sent from the Manager to the Endpoint, which mostly just amounts to
+    saying which tasks are now RUNNING.
+    """
+
+    message_type = MessageType.MANAGER_STATUS_REPORT
+
+    def __init__(self, task_statuses: t.Dict[str, t.Any], container_switch_count: int):
+        self.task_statuses = task_statuses
+        self.container_switch_count = container_switch_count
+
+    def get_v0_body(self) -> bytes:
+        # NOTE: it's important that this is done as a dumps(...).encode("ascii")
+        # for a full explanation, see the similar note on EPStatusReport
+        jsonified = json.dumps(
+            self.task_statuses,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("ascii")
+        # yeah, the int is being written as 10 bytes
+        # this is a strict "for compatibility" thing, and exemplifies why this is all
+        # awful and we need to switch to a well-defined protocol
+        return self.container_switch_count.to_bytes(10, "little") + jsonified
+
+    @classmethod
+    def load_v0_body(cls, buf: bytes) -> "ManagerStatusReport":
+        if len(buf) <= 10:
+            raise InvalidMessagePayloadError("ManagerStatusReport body was too short")
+
+        container_switch_count = int.from_bytes(buf[:10], "little")
+
+        buf = buf[10:]
+        jsonified = buf.decode("ascii")
+        try:
+            task_statuses = json.loads(jsonified)
+        except ValueError as e:
+            raise InvalidMessagePayloadError(
+                "ManagerStatusReport body failed to load as JSON"
+            ) from e
+        return cls(task_statuses, container_switch_count)

--- a/src/funcx_common/messagepack/message_types/manager_status_report.py
+++ b/src/funcx_common/messagepack/message_types/manager_status_report.py
@@ -2,7 +2,7 @@ import json
 import typing as t
 
 from ..common import Message, MessageType
-from ..exceptions import InvalidMessagePayloadError
+from ..exceptions import InvalidMessageError, InvalidMessagePayloadError
 
 
 class ManagerStatusReport(Message):
@@ -14,6 +14,11 @@ class ManagerStatusReport(Message):
     message_type = MessageType.MANAGER_STATUS_REPORT
 
     def __init__(self, task_statuses: t.Dict[str, t.Any], container_switch_count: int):
+        if not isinstance(task_statuses, dict):
+            raise InvalidMessageError(
+                "EPStatusReport inner json data was improperly shaped"
+            )
+
         self.task_statuses = task_statuses
         self.container_switch_count = container_switch_count
 

--- a/src/funcx_common/messagepack/message_types/results_ack.py
+++ b/src/funcx_common/messagepack/message_types/results_ack.py
@@ -1,0 +1,27 @@
+import uuid
+
+from ..common import Message, MessageType
+from ..exceptions import InvalidMessagePayloadError
+
+
+class ResultsAck(Message):
+    message_type = MessageType.RESULTS_ACK
+
+    def __init__(self, task_id: str):
+        self.task_id = task_id
+
+    def get_v0_body(self) -> bytes:
+        return self.task_id.encode("ascii")
+
+    @classmethod
+    def load_v0_body(cls, buf: bytes) -> "ResultsAck":
+        data = buf.decode("ascii")
+
+        try:
+            uuid.UUID(data)
+        except ValueError as e:
+            raise InvalidMessagePayloadError(
+                "ResultsAck data does not appear to be a UUID"
+            ) from e
+
+        return cls(task_id=data)

--- a/src/funcx_common/messagepack/message_types/results_ack.py
+++ b/src/funcx_common/messagepack/message_types/results_ack.py
@@ -1,13 +1,20 @@
 import uuid
 
 from ..common import Message, MessageType
-from ..exceptions import InvalidMessagePayloadError
+from ..exceptions import InvalidMessageError
 
 
 class ResultsAck(Message):
     message_type = MessageType.RESULTS_ACK
 
     def __init__(self, task_id: str):
+        try:
+            uuid.UUID(task_id)
+        except ValueError as e:
+            raise InvalidMessageError(
+                "ResultsAck data does not appear to be a UUID"
+            ) from e
+
         self.task_id = task_id
 
     def get_v0_body(self) -> bytes:
@@ -16,12 +23,4 @@ class ResultsAck(Message):
     @classmethod
     def load_v0_body(cls, buf: bytes) -> "ResultsAck":
         data = buf.decode("ascii")
-
-        try:
-            uuid.UUID(data)
-        except ValueError as e:
-            raise InvalidMessagePayloadError(
-                "ResultsAck data does not appear to be a UUID"
-            ) from e
-
-        return cls(task_id=data)
+        return cls(data)

--- a/src/funcx_common/messagepack/message_types/task.py
+++ b/src/funcx_common/messagepack/message_types/task.py
@@ -1,0 +1,33 @@
+import typing as t
+
+from ..common import Message, MessageType
+
+
+class Task(Message):
+    message_type = MessageType.TASK
+
+    def __init__(
+        self,
+        task_id: str,
+        container_id: str,
+        task_buffer: str,
+        raw_buffer: t.Optional[bytes] = None,
+    ):
+        self.task_id = task_id
+        self.container_id = container_id
+        self.task_buffer = task_buffer
+        self.raw_buffer = raw_buffer
+
+    def get_v0_body(self) -> bytes:
+        if self.raw_buffer is None:
+            self.raw_buffer = (
+                f"TID={self.task_id};CID={self.container_id};{self.task_buffer}".encode(
+                    "utf-8"
+                )
+            )
+        return self.raw_buffer
+
+    @classmethod
+    def load_v0_body(cls, buf: bytes) -> "Task":
+        b_tid, b_cid, task_buf = buf.decode("utf-8").split(";", 2)
+        return cls(b_tid[4:], b_cid[4:], task_buf, raw_buffer=buf)

--- a/src/funcx_common/messagepack/message_types/task.py
+++ b/src/funcx_common/messagepack/message_types/task.py
@@ -2,7 +2,7 @@ import typing as t
 import uuid
 
 from ..common import Message, MessageType
-from ..exceptions import InvalidMessagePayloadError
+from ..exceptions import InvalidMessageError, InvalidMessagePayloadError
 
 
 class Task(Message):
@@ -15,6 +15,19 @@ class Task(Message):
         task_buffer: str,
         raw_buffer: t.Optional[bytes] = None,
     ):
+        try:
+            uuid.UUID(task_id)
+        except ValueError as e:
+            raise InvalidMessageError(
+                "Task message task_id does not appear to be a UUID"
+            ) from e
+        try:
+            uuid.UUID(container_id)
+        except ValueError as e:
+            raise InvalidMessageError(
+                "Task message container_id does not appear to be a UUID"
+            ) from e
+
         self.task_id = task_id
         self.container_id = container_id
         self.task_buffer = task_buffer
@@ -45,17 +58,4 @@ class Task(Message):
         tid = tid[4:]
         cid = cid[4:]
 
-        try:
-            uuid.UUID(tid)
-        except ValueError as e:
-            raise InvalidMessagePayloadError(
-                "Task data contains TID which does not appear to be a UUID"
-            ) from e
-
-        try:
-            uuid.UUID(cid)
-        except ValueError as e:
-            raise InvalidMessagePayloadError(
-                "Task data contains CID which does not appear to be a UUID"
-            ) from e
         return cls(tid, cid, task_buf, raw_buffer=buf)

--- a/src/funcx_common/messagepack/packer.py
+++ b/src/funcx_common/messagepack/packer.py
@@ -1,0 +1,31 @@
+import typing as t
+
+from .common import Message
+from .protocol import MessagePackProtocol
+from .protocol_versions.proto0 import MessagePackProtocolV0
+
+
+class MessagePacker:
+    IMPLEMENTATIONS: t.Dict[int, MessagePackProtocol] = {
+        0: MessagePackProtocolV0(),
+    }
+
+    def __init__(self, default_protocol_version: int = 0) -> None:
+        self._default_protocol_version = 0
+
+    # TODO: when new protocol versions are added, replace with protocol detection logic
+    def detect_protocol_version(self, buf: bytes) -> int:
+        return 0
+
+    def pack(
+        self, message: Message, *, protocol_version: t.Optional[int] = None
+    ) -> bytes:
+        if protocol_version is None:
+            protocol_version = self._default_protocol_version
+        impl = self.IMPLEMENTATIONS[protocol_version]
+        return impl.pack(message)
+
+    def unpack(self, buf: bytes) -> Message:
+        protocol_version = self.detect_protocol_version(buf)
+        impl = self.IMPLEMENTATIONS[protocol_version]
+        return impl.unpack(buf)

--- a/src/funcx_common/messagepack/protocol.py
+++ b/src/funcx_common/messagepack/protocol.py
@@ -1,0 +1,27 @@
+"""
+The python protocol definition.
+
+A MessagePackProtocol only needs to define two actions:
+  - pack()
+  - unpack()
+
+And the two must be inverses on any valid inputs.
+"""
+
+import abc
+
+from .common import Message
+
+
+class MessagePackProtocol(abc.ABC):
+    @abc.abstractmethod
+    def pack(self, message: Message) -> bytes:
+        """
+        Pack a message into bytes.
+        """
+
+    @abc.abstractmethod
+    def unpack(self, buf: bytes) -> Message:
+        """
+        Unpack bytes into a message.
+        """

--- a/src/funcx_common/messagepack/protocol_versions/proto0.py
+++ b/src/funcx_common/messagepack/protocol_versions/proto0.py
@@ -27,7 +27,7 @@ from struct import Struct
 
 from ..common import Message, MessageType
 from ..exceptions import UnrecognizedMessageTypeError
-from ..message_types import HeartbeatReq, Task
+from ..message_types import ALL_MESSAGE_TYPES
 from ..protocol import MessagePackProtocol
 
 _MESSAGE_TYPE_FORMATTER = Struct("b")
@@ -57,5 +57,5 @@ class MessagePackProtocolV0(MessagePackProtocol):
         cls.MESSAGE_TYPE_MAP[message_class.message_type] = message_class
 
 
-MessagePackProtocolV0.register_message_type(HeartbeatReq)
-MessagePackProtocolV0.register_message_type(Task)
+for m in ALL_MESSAGE_TYPES:
+    MessagePackProtocolV0.register_message_type(m)

--- a/src/funcx_common/messagepack/protocol_versions/proto0.py
+++ b/src/funcx_common/messagepack/protocol_versions/proto0.py
@@ -27,7 +27,7 @@ from struct import Struct
 
 from ..common import Message, MessageType
 from ..exceptions import UnrecognizedMessageTypeError
-from ..message_types import ALL_MESSAGE_TYPES
+from ..message_types import ALL_MESSAGE_CLASSES
 from ..protocol import MessagePackProtocol
 
 _MESSAGE_TYPE_FORMATTER = Struct("b")
@@ -57,5 +57,5 @@ class MessagePackProtocolV0(MessagePackProtocol):
         cls.MESSAGE_TYPE_MAP[message_class.message_type] = message_class
 
 
-for m in ALL_MESSAGE_TYPES:
+for m in ALL_MESSAGE_CLASSES:
     MessagePackProtocolV0.register_message_type(m)

--- a/src/funcx_common/messagepack/protocol_versions/proto0.py
+++ b/src/funcx_common/messagepack/protocol_versions/proto0.py
@@ -1,0 +1,61 @@
+"""
+This file defines Protocol Version 0 of the funcx messagepack protocol.
+
+v0 of the protocol does the following:
+- messages are encoded as packed bytes with the python `struct` library
+- the first byte is always the message type
+- messages may be packed as strings with inner delimiters
+
+For example, under protocol v0, a heartbeat request message can be formulated with
+
+    >>> packer = struct.Struct('b')
+    >>> packer.pack(1)
+
+where `1` is the indicator for heartbeat requests.
+
+A Task message can be formulated with
+
+    >>> packer = struct.Struct('b')
+    >>> msg = packer.pack(5)  # 5 is for Tasks
+    >>> msg += f"TID={task_id};CID={container_id};{task_buffer}".encode("utf-8")
+
+Note that this means that message unpacking in v0 may require additional parsing. In the
+case of tasks, `message.split(";", 2)` is needed.
+"""
+import typing as t
+from struct import Struct
+
+from ..common import Message, MessageType
+from ..exceptions import UnrecognizedMessageTypeError
+from ..message_types import HeartbeatReq, Task
+from ..protocol import MessagePackProtocol
+
+_MESSAGE_TYPE_FORMATTER = Struct("b")
+
+
+class MessagePackProtocolV0(MessagePackProtocol):
+    MESSAGE_TYPE_MAP: t.Dict[MessageType, t.Type[Message]] = {}
+
+    def pack(self, message: Message) -> bytes:
+        prefix = _MESSAGE_TYPE_FORMATTER.pack(message.message_type.value)
+        body = message.get_v0_body()
+        return prefix + body
+
+    def unpack(self, buf: bytes) -> Message:
+        (message_type,) = _MESSAGE_TYPE_FORMATTER.unpack_from(buf, offset=0)
+        remainder = buf[_MESSAGE_TYPE_FORMATTER.size :]
+        try:
+            mtype = MessageType(message_type)
+        except ValueError as e:
+            raise UnrecognizedMessageTypeError(f"message_type={message_type}") from e
+
+        message_class = self.MESSAGE_TYPE_MAP[mtype]
+        return message_class.load_v0_body(remainder)
+
+    @classmethod
+    def register_message_type(cls, message_class: t.Type[Message]) -> None:
+        cls.MESSAGE_TYPE_MAP[message_class.message_type] = message_class
+
+
+MessagePackProtocolV0.register_message_type(HeartbeatReq)
+MessagePackProtocolV0.register_message_type(Task)

--- a/tests/functional/messagepack/test_endpoint_compatibility.py
+++ b/tests/functional/messagepack/test_endpoint_compatibility.py
@@ -3,11 +3,17 @@ import uuid
 import pytest
 
 from funcx_common.messagepack import MessagePacker
-from funcx_common.messagepack.message_types import Task
+from funcx_common.messagepack.message_types import (
+    EPStatusReport,
+    Heartbeat,
+    HeartbeatReq,
+    ManagerStatusReport,
+    ResultsAck,
+    Task,
+)
 
 try:
-    from funcx_endpoint.executors.high_throughput.messages import Message as EP_Message
-    from funcx_endpoint.executors.high_throughput.messages import Task as EP_Task
+    from funcx_endpoint.executors.high_throughput import messages as EP
 except ImportError:
     pytest.skip(
         "these tests require availability of the funcx_endpoint package",
@@ -20,15 +26,94 @@ def v0_packer():
     return MessagePacker(default_protocol_version=0)
 
 
-def test_task_compatibility(v0_packer):
+def test_ep_status_report(v0_packer):
+    endpoint_id = str(uuid.uuid1())
+    orig = EPStatusReport(endpoint_id, {"foo": "bar"}, {"foo": "baz"})
+    on_wire = v0_packer.pack(orig)
+
+    ep_report = EP.Message.unpack(on_wire)
+    assert isinstance(ep_report, EP.EPStatusReport)
+    # there is no `endpoint_id`, just the bytes of the ID in a field named `_header`
+    # this assert is "what we mean":
+    #   assert ep_report.endpoint_id == endpoint_id
+    assert str(uuid.UUID(bytes=ep_report._header)) == endpoint_id
+    assert ep_report.ep_status == {"foo": "bar"}
+    assert ep_report.task_statuses == {"foo": "baz"}
+
+    on_wire2 = ep_report.pack()
+    common_report = v0_packer.unpack(on_wire2)
+    assert isinstance(common_report, EPStatusReport)
+    assert common_report.endpoint_id == endpoint_id
+    assert common_report.ep_status == {"foo": "bar"}
+    assert common_report.task_statuses == {"foo": "baz"}
+
+
+def test_heartbeat(v0_packer):
+    endpoint_id = str(uuid.uuid1())
+    orig = Heartbeat(endpoint_id)
+    on_wire = v0_packer.pack(orig)
+
+    ep_hb = EP.Message.unpack(on_wire)
+    assert isinstance(ep_hb, EP.Heartbeat)
+    assert ep_hb.endpoint_id == endpoint_id
+
+    on_wire2 = ep_hb.pack()
+    common_hb = v0_packer.unpack(on_wire2)
+    assert isinstance(common_hb, Heartbeat)
+    assert common_hb.endpoint_id == endpoint_id
+
+
+def test_heartbeat_req(v0_packer):
+    orig = HeartbeatReq()
+    on_wire = v0_packer.pack(orig)
+
+    ep_hbr = EP.Message.unpack(on_wire)
+    assert isinstance(ep_hbr, EP.HeartbeatReq)
+
+    on_wire2 = ep_hbr.pack()
+    common_hbr = v0_packer.unpack(on_wire2)
+    assert isinstance(common_hbr, HeartbeatReq)
+
+
+def test_manager_status_report(v0_packer):
+    orig = ManagerStatusReport({"foo": "bar"}, 105)
+    on_wire = v0_packer.pack(orig)
+
+    ep_report = EP.Message.unpack(on_wire)
+    assert isinstance(ep_report, EP.ManagerStatusReport)
+    assert ep_report.task_statuses == {"foo": "bar"}
+    assert ep_report.container_switch_count == 105
+
+    on_wire2 = ep_report.pack()
+    common_report = v0_packer.unpack(on_wire2)
+    assert isinstance(common_report, ManagerStatusReport)
+    assert common_report.task_statuses == {"foo": "bar"}
+    assert common_report.container_switch_count == 105
+
+
+def test_results_ack(v0_packer):
+    task_id = str(uuid.uuid1())
+    orig = ResultsAck(task_id)
+    on_wire = v0_packer.pack(orig)
+
+    ep_ack = EP.Message.unpack(on_wire)
+    assert isinstance(ep_ack, EP.ResultsAck)
+    assert ep_ack.task_id == task_id
+
+    on_wire2 = ep_ack.pack()
+    common_ack = v0_packer.unpack(on_wire2)
+    assert isinstance(common_ack, ResultsAck)
+    assert common_ack.task_id == task_id
+
+
+def test_task(v0_packer):
     task_id = str(uuid.uuid1())
     container_id = str(uuid.uuid1())
-    orig_task = Task(task_id, container_id, "some data")
+    orig = Task(task_id, container_id, "some data")
+    on_wire = v0_packer.pack(orig)
 
-    on_wire = v0_packer.pack(orig_task)
-
-    ep_task = EP_Message.unpack(on_wire)
-    assert isinstance(ep_task, EP_Task)
+    ep_task = EP.Message.unpack(on_wire)
+    assert isinstance(ep_task, EP.Task)
     assert ep_task.task_id == task_id
     assert ep_task.container_id == container_id
     # NOTE: this is a known difference between the implementations, that
@@ -37,7 +122,6 @@ def test_task_compatibility(v0_packer):
     assert ep_task.task_buffer == b"some data"
 
     on_wire2 = ep_task.pack()
-
     common_task = v0_packer.unpack(on_wire2)
     assert isinstance(common_task, Task)
     assert common_task.task_id == task_id

--- a/tests/functional/messagepack/test_endpoint_compatibility.py
+++ b/tests/functional/messagepack/test_endpoint_compatibility.py
@@ -1,0 +1,45 @@
+import uuid
+
+import pytest
+
+from funcx_common.messagepack import MessagePacker
+from funcx_common.messagepack.message_types import Task
+
+try:
+    from funcx_endpoint.executors.high_throughput.messages import Message as EP_Message
+    from funcx_endpoint.executors.high_throughput.messages import Task as EP_Task
+except ImportError:
+    pytest.skip(
+        "these tests require availability of the funcx_endpoint package",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture
+def v0_packer():
+    return MessagePacker(default_protocol_version=0)
+
+
+def test_task_compatibility(v0_packer):
+    task_id = str(uuid.uuid1())
+    container_id = str(uuid.uuid1())
+    orig_task = Task(task_id, container_id, "some data")
+
+    on_wire = v0_packer.pack(orig_task)
+
+    ep_task = EP_Message.unpack(on_wire)
+    assert isinstance(ep_task, EP_Task)
+    assert ep_task.task_id == task_id
+    assert ep_task.container_id == container_id
+    # NOTE: this is a known difference between the implementations, that
+    # `funcx-endpoint` implements this as storing bytes when loaded, but
+    # `funcx-common` will store as a string instead
+    assert ep_task.task_buffer == b"some data"
+
+    on_wire2 = ep_task.pack()
+
+    common_task = v0_packer.unpack(on_wire2)
+    assert isinstance(common_task, Task)
+    assert common_task.task_id == task_id
+    assert common_task.container_id == container_id
+    assert common_task.task_buffer == "some data"

--- a/tests/unit/test_messagepack.py
+++ b/tests/unit/test_messagepack.py
@@ -1,0 +1,73 @@
+import uuid
+
+import pytest
+
+from funcx_common.messagepack import (
+    HeartbeatReq,
+    MessagePacker,
+    Task,
+    UnrecognizedMessageTypeError,
+)
+
+
+def test_can_manually_v0_get_and_load_heartbeat_req():
+    req_obj = HeartbeatReq()
+    # body is empty
+    assert req_obj.get_v0_body() == b""
+
+    # just ensure that loading does not error; nothing more can be tested here
+    HeartbeatReq.load_v0_body(req_obj.get_v0_body())
+
+
+def test_can_manually_v0_get_and_load_task():
+    task_id = str(uuid.uuid1())
+    container_id = str(uuid.uuid1())
+    task_obj = Task(task_id, container_id, "some data")
+
+    assert task_obj.task_id == task_id
+    assert task_obj.container_id == container_id
+    assert task_obj.container_id == container_id
+    assert task_obj.task_buffer == "some data"
+
+    on_wire = task_obj.get_v0_body()
+    assert on_wire == f"TID={task_id};CID={container_id};some data".encode("utf-8")
+
+    task_obj2 = Task.load_v0_body(on_wire)
+    assert task_obj2.task_id == task_id
+    assert task_obj2.container_id == container_id
+    assert task_obj2.task_buffer == "some data"
+    assert (
+        task_obj2.get_v0_body()
+        == f"TID={task_id};CID={container_id};some data".encode("utf-8")
+    )
+
+
+def test_can_pack_and_unpack_task_v0():
+    packer = MessagePacker(default_protocol_version=0)
+
+    task_id = str(uuid.uuid1())
+    container_id = str(uuid.uuid1())
+    task_obj = Task(task_id, container_id, "some data")
+
+    on_wire = packer.pack(task_obj)
+    payload = f"TID={task_id};CID={container_id};some data".encode("utf-8")
+    # note, the v0 protocol is sensitive to the message type values
+    # "TASK" is 5
+    header = b"\x05"
+    assert on_wire == header + payload
+
+    task_obj2 = packer.unpack(on_wire)
+    assert task_obj2.task_id == task_id
+    assert task_obj2.container_id == container_id
+    assert task_obj2.task_buffer == "some data"
+
+
+def test_cannot_unpack_unknown_message_type():
+    packer = MessagePacker()
+
+    # as a packed byte, '100'
+    header = b"d"
+    payload = b"some message"
+
+    with pytest.raises(UnrecognizedMessageTypeError):
+        packer.unpack(header + payload)

--- a/tests/unit/test_messagepack.py
+++ b/tests/unit/test_messagepack.py
@@ -5,7 +5,7 @@ import uuid
 import pytest
 
 from funcx_common.messagepack import (
-    InvalidMessagePayloadError,
+    InvalidMessageError,
     Message,
     MessagePacker,
     MessageType,
@@ -191,6 +191,7 @@ def test_can_pack_and_unpack_resultsack_v0(v0_packer):
         (MessageType.MANAGER_STATUS_REPORT, b"foo"),
         (MessageType.MANAGER_STATUS_REPORT, VALID_CSC_SEGMENT),
         (MessageType.MANAGER_STATUS_REPORT, VALID_CSC_SEGMENT + b"{"),
+        (MessageType.MANAGER_STATUS_REPORT, VALID_CSC_SEGMENT + b"[]"),
         (MessageType.EP_STATUS_REPORT, b"foo"),
         (MessageType.EP_STATUS_REPORT, b"foo" * 10),
         (MessageType.EP_STATUS_REPORT, ID_ZERO.bytes + b"{"),
@@ -207,5 +208,5 @@ def test_can_pack_and_unpack_resultsack_v0(v0_packer):
 )
 def test_invalid_v0_unpack(message_type, message, v0_packer):
     header = get_v0_header(message_type)
-    with pytest.raises(InvalidMessagePayloadError):
+    with pytest.raises(InvalidMessageError):
         v0_packer.unpack(header + message)

--- a/tests/unit/test_messagepack.py
+++ b/tests/unit/test_messagepack.py
@@ -1,13 +1,36 @@
+import json
+import struct
 import uuid
 
 import pytest
 
 from funcx_common.messagepack import (
+    EPStatusReport,
+    Heartbeat,
     HeartbeatReq,
+    InvalidMessagePayloadError,
+    ManagerStatusReport,
+    Message,
     MessagePacker,
+    MessageType,
     Task,
     UnrecognizedMessageTypeError,
 )
+
+ID_ZERO = uuid.UUID(int=0)
+
+
+@pytest.fixture
+def v0_packer():
+    return MessagePacker(default_protocol_version=0)
+
+
+def get_v0_header(m):  # takes Message or MessageType or int
+    if isinstance(m, Message):
+        m = m.message_type
+    if isinstance(m, MessageType):
+        m = m.value
+    return struct.pack("b", m)
 
 
 def test_can_manually_v0_get_and_load_heartbeat_req():
@@ -42,32 +65,130 @@ def test_can_manually_v0_get_and_load_task():
     )
 
 
-def test_can_pack_and_unpack_task_v0():
-    packer = MessagePacker(default_protocol_version=0)
-
+def test_can_pack_and_unpack_task_v0(v0_packer):
     task_id = str(uuid.uuid1())
     container_id = str(uuid.uuid1())
     task_obj = Task(task_id, container_id, "some data")
 
-    on_wire = packer.pack(task_obj)
+    on_wire = v0_packer.pack(task_obj)
     payload = f"TID={task_id};CID={container_id};some data".encode("utf-8")
-    # note, the v0 protocol is sensitive to the message type values
-    # "TASK" is 5
-    header = b"\x05"
+    header = get_v0_header(MessageType.TASK)
     assert on_wire == header + payload
 
-    task_obj2 = packer.unpack(on_wire)
+    task_obj2 = v0_packer.unpack(on_wire)
     assert task_obj2.task_id == task_id
     assert task_obj2.container_id == container_id
     assert task_obj2.task_buffer == "some data"
 
 
-def test_cannot_unpack_unknown_message_type():
-    packer = MessagePacker()
-
-    # as a packed byte, '100'
-    header = b"d"
+def test_cannot_unpack_unknown_message_type(v0_packer):
+    # '100' does not match any real header values
+    header = get_v0_header(100)
     payload = b"some message"
 
     with pytest.raises(UnrecognizedMessageTypeError):
-        packer.unpack(header + payload)
+        v0_packer.unpack(header + payload)
+
+
+# this is the v0 "container_switch_count" encoding
+# it's not a complete message; just a valid message fragment for a
+# ManagerStatusReport message
+VALID_CSC_SEGMENT = (5).to_bytes(10, "little")
+
+
+@pytest.mark.parametrize(
+    "task_statuses",
+    [
+        {},
+        {"foo": "bar"},
+        {str(n): {"foo": "bar"} for n in range(1000)},
+    ],
+)
+def test_can_pack_and_unpack_manager_status_report_v0(v0_packer, task_statuses):
+    report = ManagerStatusReport(task_statuses, 5)
+
+    task_statuses_s = json.dumps(task_statuses, separators=(",", ":"), sort_keys=True)
+    task_statuses_b = task_statuses_s.encode("ascii")
+
+    on_wire = v0_packer.pack(report)
+    header = get_v0_header(MessageType.MANAGER_STATUS_REPORT)
+    payload = VALID_CSC_SEGMENT + task_statuses_b
+    assert on_wire == header + payload
+
+    report2 = v0_packer.unpack(on_wire)
+    assert report2.container_switch_count == 5
+    assert report2.task_statuses == task_statuses
+
+
+def test_can_pack_and_unpack_heartbeat_v0(v0_packer):
+    hb = Heartbeat(str(ID_ZERO))
+
+    on_wire = v0_packer.pack(hb)
+    header = get_v0_header(MessageType.HEARTBEAT)
+    payload = str(ID_ZERO).encode("ascii")
+    assert on_wire == header + payload
+
+    hb2 = v0_packer.unpack(on_wire)
+    assert hb2.endpoint_id == str(ID_ZERO)
+
+
+@pytest.mark.parametrize(
+    "task_statuses",
+    [
+        {},
+        {"foo": "bar"},
+        {str(n): {"foo": "bar"} for n in range(1000)},
+    ],
+)
+@pytest.mark.parametrize(
+    "ep_status",
+    [{}, {"foo": "bar"}],
+)
+def test_can_pack_and_unpack_ep_status_report_v0(v0_packer, ep_status, task_statuses):
+    report = EPStatusReport(str(ID_ZERO), ep_status, task_statuses)
+
+    on_wire = v0_packer.pack(report)
+    header = get_v0_header(MessageType.EP_STATUS_REPORT)
+    payload = ID_ZERO.bytes + json.dumps(
+        [ep_status, task_statuses], separators=(",", ":"), sort_keys=True
+    ).encode("ascii")
+    assert on_wire == header + payload
+
+    report2 = v0_packer.unpack(on_wire)
+    assert report2.endpoint_id == str(ID_ZERO)
+    assert report2.ep_status == ep_status
+    assert report2.task_statuses == task_statuses
+
+
+@pytest.mark.parametrize(
+    "message_type, message",
+    [
+        (MessageType.TASK, b""),
+        (MessageType.TASK, b"foo"),
+        (MessageType.TASK, b"foo;bar"),
+        (MessageType.TASK, b"TID=;CID=;foo"),
+        (MessageType.TASK, b";;foo"),
+        (MessageType.TASK, f"TID={ID_ZERO};CID=;foo".encode("utf-8")),
+        (MessageType.TASK, f"TID=;CID={ID_ZERO};foo".encode("utf-8")),
+        (MessageType.TASK, f"TID={ID_ZERO};CID={ID_ZERO}".encode("utf-8")),
+        (MessageType.HEARTBEAT, b"foo"),
+        (MessageType.MANAGER_STATUS_REPORT, b""),
+        (MessageType.MANAGER_STATUS_REPORT, b"foo"),
+        (MessageType.MANAGER_STATUS_REPORT, VALID_CSC_SEGMENT),
+        (MessageType.MANAGER_STATUS_REPORT, VALID_CSC_SEGMENT + b"{"),
+        (MessageType.EP_STATUS_REPORT, b"foo"),
+        (MessageType.EP_STATUS_REPORT, b"foo" * 10),
+        (MessageType.EP_STATUS_REPORT, ID_ZERO.bytes + b"{"),
+        (MessageType.EP_STATUS_REPORT, b"*" * 100),
+        (MessageType.EP_STATUS_REPORT, ID_ZERO.bytes + b"{}"),
+        (MessageType.EP_STATUS_REPORT, ID_ZERO.bytes + b"[]"),
+        (MessageType.EP_STATUS_REPORT, ID_ZERO.bytes + b"[null,null]"),
+        (MessageType.EP_STATUS_REPORT, ID_ZERO.bytes + b"[{},null]"),
+        (MessageType.EP_STATUS_REPORT, ID_ZERO.bytes + b"[null,{}]"),
+        (MessageType.EP_STATUS_REPORT, ID_ZERO.bytes + b"[{},{},{}]"),
+    ],
+)
+def test_invalid_v0_unpack(message_type, message, v0_packer):
+    header = get_v0_header(message_type)
+    with pytest.raises(InvalidMessagePayloadError):
+        v0_packer.unpack(header + message)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = cov-clean,py{310,36}-nodeps,py{310,39,38,37,36},cov-report
+envlist = cov-clean,py{310,36}-nodeps,py37-withendpoint,py{310,39,38,37,36},cov-report
 skip_missing_interpreters = true
 
 [testenv]
@@ -16,6 +16,8 @@ extras =
     !nodeps: boto3
     !nodeps: moto
     !nodeps: redis
+deps =
+    withendpoint: funcx-endpoint
 commands = pytest --cov=src --cov-append --cov-report= {posargs}
 depends =
     {py36-nodeps,py310-nodeps,py36,py37,py38,py39,py310}: cov-clean


### PR DESCRIPTION
"messagepack" is the (new) name of the message passing protocol for use between the forwarder and endpoints. This defines a multiplexer for various supported protocol versions, called `MessagePacker`, which can convert message objects to and from bytes.

For now, only protocol version 0 is defined, it is set as the default, and version detection is a stub (which just returns 0).

Plans for v1, differences from the source `funcx-endpoint` message definitions, and other details are described in a subpackage-specific readme file.

~So far, only Task and HeartbeatReq have been implemented, with plans for all of the other necessary message types.~

I originally wanted the v0 protocol object to have the implementations for the various message types, but it got out of control because this isn't a well-defined protocol (yet). That's why each message has a `get_v0_body` and `load_v0_body` method -- to handle their "v0 variants". Hopefully v1 or later will let us unify the implementation a bit.