### PR TITLE
Allow for non-S3 task storage

### DIFF
--- a/changelog.d/20211122_192309_sirosen_allow_no_s3_storage.md
+++ b/changelog.d/20211122_192309_sirosen_allow_no_s3_storage.md
@@ -1,0 +1,21 @@
+### Added
+
+- Add the `funcx_common.task_storage.get_default_task_storage()` method, which
+  reads the `FUNCX_REDIS_STORAGE_THRESHOLD` and `FUNCX_S3_BUCKET_NAME` environment
+  variables and constructs the appropriate TaskStorage object
+
+  - Detection of S3/Redis vs Redis-only storage is done by the presence/absence
+    of the `FUNCX_S3_BUCKET_NAME` variable. It can be forced to redis-only by
+    setting `FUNCX_REDIS_STORAGE_THRESHOLD="-1"`
+  - The storage threshold has a default value of 20,000 if not set
+
+- Add `funcx_common.task_storage.ImplicitRedisStorage` as a storage class which
+  only reads and writes the task object, on the assumption that it is a
+  RedisTask
+
+### Changed
+
+- RedisS3Storage now contains an ImplicitRedisStorage object which is used to
+  implement read/write to redis
+- RedisS3Storage now requires `bucket_name` and `redis_threshold` as
+  keyword-only arguments, if constructed directly

--- a/src/funcx_common/task_storage/__init__.py
+++ b/src/funcx_common/task_storage/__init__.py
@@ -1,4 +1,12 @@
 from .base import StorageException, TaskStorage
+from .default_storage import get_default_task_storage
+from .redis import ImplicitRedisStorage
 from .s3 import RedisS3Storage
 
-__all__ = ("TaskStorage", "StorageException", "RedisS3Storage")
+__all__ = (
+    "TaskStorage",
+    "StorageException",
+    "RedisS3Storage",
+    "ImplicitRedisStorage",
+    "get_default_task_storage",
+)

--- a/src/funcx_common/task_storage/default_storage.py
+++ b/src/funcx_common/task_storage/default_storage.py
@@ -1,13 +1,9 @@
-import logging
 import os
 import typing as t
 
 from .base import TaskStorage
 from .redis import ImplicitRedisStorage
 from .s3 import RedisS3Storage
-
-log = logging.getLogger(__name__)
-
 
 DEFAULT_REDIS_STORAGE_THRESHOLD: int = 20000
 
@@ -17,12 +13,10 @@ def _get_redis_storage_threshold() -> int:
     if val is not None:
         try:
             return int(val)
-        except ValueError:
-            log.warning(
-                "could not parse FUNCX_REDIS_STORAGE_THRESHOLD=%s as int, "
-                "will failover to default",
-                val,
-            )
+        except ValueError as err:
+            raise ValueError(
+                f"could not parse FUNCX_REDIS_STORAGE_THRESHOLD={val} as int"
+            ) from err
     return DEFAULT_REDIS_STORAGE_THRESHOLD
 
 

--- a/src/funcx_common/task_storage/default_storage.py
+++ b/src/funcx_common/task_storage/default_storage.py
@@ -1,0 +1,43 @@
+import logging
+import os
+import typing as t
+
+from .base import TaskStorage
+from .redis import ImplicitRedisStorage
+from .s3 import RedisS3Storage
+
+log = logging.getLogger(__name__)
+
+
+DEFAULT_REDIS_STORAGE_THRESHOLD: int = 20000
+
+
+def _get_redis_storage_threshold() -> int:
+    val = os.getenv("FUNCX_REDIS_STORAGE_THRESHOLD")
+    if val is not None:
+        try:
+            return int(val)
+        except ValueError:
+            log.warning(
+                "could not parse FUNCX_REDIS_STORAGE_THRESHOLD=%s as int, "
+                "will failover to default",
+                val,
+            )
+    return DEFAULT_REDIS_STORAGE_THRESHOLD
+
+
+def _s3_bucket_name() -> t.Optional[str]:
+    return os.getenv("FUNCX_S3_BUCKET_NAME")
+
+
+def get_default_task_storage() -> TaskStorage:
+    bucket = _s3_bucket_name()
+    threshold = _get_redis_storage_threshold()
+
+    # a redis threshold of -1 means "never use S3, just use Redis"
+    if bucket is None or threshold == -1:
+        return ImplicitRedisStorage()
+    else:
+        return RedisS3Storage(
+            bucket_name=bucket, redis_threshold=_get_redis_storage_threshold()
+        )

--- a/src/funcx_common/task_storage/redis.py
+++ b/src/funcx_common/task_storage/redis.py
@@ -1,0 +1,26 @@
+import typing as t
+
+from ..tasks import TaskProtocol
+from .base import TaskStorage
+
+
+class ImplicitRedisStorage(TaskStorage):
+    """
+    This storage adapter stores task data to redis only.
+
+    It is named "implicit" because it assumes that the task object itself is some form
+    of RedisTask which will write to redis either on setattr or some save/commit step.
+    """
+
+    def store_result(
+        self,
+        task: TaskProtocol,
+        result: str,
+    ) -> None:
+        task.result = result
+        task.result_reference = {"storage_id": "redis"}
+
+    def get_result(self, task: TaskProtocol) -> t.Optional[str]:
+        if task.result:
+            return task.result
+        return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,11 +14,15 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture
-def funcx_s3_bucket(pytestconfig):
+def funcx_s3_bucket(pytestconfig, monkeypatch):
     value = pytestconfig.getoption("--funcx-s3-bucket")
+
     if value is not None:
-        return value[0]
-    return value
+        value = value[0]
+        monkeypatch.setenv("FUNCX_S3_BUCKET_NAME", value)
+        return value
+
+    return None
 
 
 @pytest.fixture(autouse=True)

--- a/tests/functional/storage/test_implicit_redis.py
+++ b/tests/functional/storage/test_implicit_redis.py
@@ -1,0 +1,36 @@
+import uuid
+
+from funcx_common.task_storage import ImplicitRedisStorage
+from funcx_common.tasks import TaskProtocol, TaskState
+
+
+class SimpleInMemoryTask(TaskProtocol):
+    def __init__(self):
+        self.task_id = str(uuid.uuid1())
+        self.endpoint = None
+        self.status = TaskState.RECEIVED
+        self.result = None
+        self.result_reference = None
+
+
+def test_implicit_redis_no_result():
+    store = ImplicitRedisStorage()
+    task = SimpleInMemoryTask()
+
+    assert store.get_result(task) is None
+
+
+def test_implicit_redis_roundtrip_data():
+    store = ImplicitRedisStorage()
+    task = SimpleInMemoryTask()
+
+    assert store.get_result(task) is None
+    store.store_result(task, "foo")
+
+    assert task.result == "foo"
+    assert isinstance(task.result_reference, dict)
+    assert "storage_id" in task.result_reference
+    assert task.result_reference["storage_id"] == "redis"
+
+    result = store.get_result(task)
+    assert result == "foo"

--- a/tests/functional/storage/test_s3_functional.py
+++ b/tests/functional/storage/test_s3_functional.py
@@ -7,10 +7,11 @@ from funcx_common.tasks import TaskProtocol, TaskState
 
 try:
     import boto3
-
-    has_boto = True
 except ImportError:
-    has_boto = False
+    pytest.skip(
+        "these tests require the boto3 lib",
+        allow_module_level=True,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -28,7 +29,6 @@ class SimpleInMemoryTask(TaskProtocol):
         self.result_reference = None
 
 
-@pytest.mark.skipif(not has_boto, reason="Test requires boto3 lib")
 def test_s3_storage(funcx_s3_bucket):
     """Confirm that data is stored to s3"""
     # We are setting threshold of 0 to force only s3 storage
@@ -42,7 +42,6 @@ def test_s3_storage(funcx_s3_bucket):
     assert task.result_reference["storage_id"] == "s3"
 
 
-@pytest.mark.skipif(not has_boto, reason="Test requires boto3 lib")
 def test_s3_storage_below_threshold(funcx_s3_bucket):
     """Confirm that data is NOT stored to s3"""
     store = RedisS3Storage(bucket_name=funcx_s3_bucket, redis_threshold=100)
@@ -60,7 +59,6 @@ def test_s3_storage_below_threshold(funcx_s3_bucket):
     assert "Contents" not in response
 
 
-@pytest.mark.skipif(not has_boto, reason="Test requires boto3 lib")
 def test_s3_storage_bad_bucket():
     """Confirm exception on bad S3 target"""
 
@@ -82,7 +80,6 @@ def test_s3_storage_bad_bucket():
     assert store.get_result(task) is None
 
 
-@pytest.mark.skipif(not has_boto, reason="Test requires boto3 lib")
 def test_s3_storage_direct(funcx_s3_bucket):
     """Confirm that data is stored to s3 via boto3"""
     # We are setting threshold of 0 to force only s3 storage
@@ -98,7 +95,6 @@ def test_s3_storage_direct(funcx_s3_bucket):
     assert len(response["Contents"]) == 1
 
 
-@pytest.mark.skipif(not has_boto, reason="Test requires boto3 lib")
 def test_s3_storage_deleted_data(funcx_s3_bucket):
     store = RedisS3Storage(bucket_name=funcx_s3_bucket, redis_threshold=0)
     result = "Hello World!"

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -53,9 +53,8 @@ def test_default_task_storage_s3(funcx_s3_bucket, monkeypatch):
 
     # now set an invalid threshold value; confirm that it is ignored
     monkeypatch.setenv("FUNCX_REDIS_STORAGE_THRESHOLD", "foo")
-    store = get_default_task_storage()
-    assert isinstance(store, RedisS3Storage)
-    assert store.redis_threshold == 20000  # default value
+    with pytest.raises(ValueError):
+        store = get_default_task_storage()
 
 
 def test_default_task_storage_redis(monkeypatch):


### PR DESCRIPTION
- Add get_default_task_storage method, which reads env vars
- Add ImplicitRedisStorage which is a redis-only object
- If S3 storage is detected (via bucket env var), the S3 storage will now contain an ImplicitRedisStorage which is used to read/write to redis (thus consolidating the currently small implementation)
- If non-S3 storage is detected, the default storage is redis
- Setting a redis threshold of -1 will force the use of redis storage, not S3, regardless of whether or not the bucket is present
- The get_default_task_storage method is responsible for setting the redis storage threshold and using the default if appropriate
- RedisS3Storage now requires the redis_threshold in its constructor, and its arguments are keyword-only (because of how this is wrapped, it should rarely matter)

Tests are included for all new and changed behaviors.

The changelog indicates the parts of this which I consider most important for consumers of funcx-common.

Changing RedisS3Storage to have an internal ImplicitRedisStorage was not strictly necessary, and doesn't save lines of code. However, it ensures that there is one implementation of read/write to Redis for TaskStorage. If we need to make changes in the future (e.g. more info in `result_reference`), we'll be able to do so in one place.

---

Brief aside: I wanted all env vars used by funcx-common to have the `FUNCX_COMMON_` prefix. However, using the existing variables is expedient and simpler for now. We can change it in the future, if there's ever any impetus to do so.