### PR TITLE
Enable mypy strict mode

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,11 +60,7 @@ extension =
 paths = ./src/funcx_common/
 
 [mypy]
-disallow_untyped_defs = true
+strict = true
 ignore_missing_imports = true
 warn_unreachable = true
 warn_unused_ignores = true
-warn_redundant_casts = true
-warn_return_any = true
-warn_no_return = true
-no_implicit_optional = true

--- a/src/funcx_common/redis/connection.py
+++ b/src/funcx_common/redis/connection.py
@@ -30,7 +30,7 @@ Either install it explicitly or install the 'redis' extra, as in
 
 def default_redis_connection_factory(
     redis_url: t.Optional[str] = None,
-) -> "redis.Redis":
+) -> "redis.Redis[t.Any]":
     """
     Construct a Redis client for a given redis URL.
     If no URL is given, the FUNCX_COMMON_REDIS_URL environment variable will be used.
@@ -54,7 +54,9 @@ def default_redis_connection_factory(
 
 
 @contextlib.contextmanager
-def redis_connection_error_logging(redis_client: "redis.Redis") -> t.Iterator[None]:
+def redis_connection_error_logging(
+    redis_client: "redis.Redis[t.Any]",
+) -> t.Iterator[None]:
     _check_has_redis()
 
     try:

--- a/src/funcx_common/redis/fields.py
+++ b/src/funcx_common/redis/fields.py
@@ -29,7 +29,7 @@ class RedisField:
                 "metaclass to HasRedisFieldsMeta."
             )
 
-    def __get__(self, owner: t.Any, ownertype: t.Type) -> t.Any:
+    def __get__(self, owner: t.Any, ownertype: t.Type[t.Any]) -> t.Any:
         self._check_null_key()
         value = owner.redis_client.hget(owner.hname, self.key)
         return None if value is None else self.serde.deserialize(value)

--- a/src/funcx_common/redis/pubsub.py
+++ b/src/funcx_common/redis/pubsub.py
@@ -45,7 +45,9 @@ class FuncxRedisPubSub:
     unsubscribing, ensure clean teardown by calling ``get_final_messages()``.
     """
 
-    def __init__(self, *, redis_client: t.Optional["redis.Redis"] = None) -> None:
+    def __init__(
+        self, *, redis_client: t.Optional["redis.Redis[t.Any]"] = None
+    ) -> None:
         if redis_client is None:
             redis_client = default_redis_connection_factory()
         self.redis_client = redis_client
@@ -122,7 +124,7 @@ class FuncxRedisPubSub:
         log.info("unsubscribing from %s", channel)
         self.pubsub.unsubscribe(channel)
 
-    def _get_message(self, timeout: float) -> t.Optional[dict]:
+    def _get_message(self, timeout: float) -> t.Optional[t.Dict[str, t.Any]]:
         # skip any subscribe/unsubscribe messages, but do not use the
         # 'ignore_subscribe_messages' flag because it behaves by returning
         # `None` rather than advancing to the next message

--- a/src/funcx_common/redis/task_queue.py
+++ b/src/funcx_common/redis/task_queue.py
@@ -10,7 +10,7 @@ if t.TYPE_CHECKING:
 
 class FuncxEndpointTaskQueue:
     def __init__(
-        self, endpoint: str, *, redis_client: t.Optional["redis.Redis"] = None
+        self, endpoint: str, *, redis_client: t.Optional["redis.Redis[t.Any]"] = None
     ) -> None:
         if redis_client is None:
             redis_client = default_redis_connection_factory()


### PR DESCRIPTION
The primary thing this disallows which is present today is "any generics", in which a generic type is not given a type parameter and the type param is therefore implicitly "Any". By way of example, `Iterator` is not allowed, but `Iterator[str]` or `Iterator[Any]` are both valid.

In most cases, this is just adding an explicit Any type.