### PR TITLE
Add payload storage

### DIFF
--- a/changelog.d/20211213_115038_yadudoc1729_add_payload_storage.md
+++ b/changelog.d/20211213_115038_yadudoc1729_add_payload_storage.md
@@ -2,12 +2,3 @@
 
 - `funcx_common.task_storage.TaskStorage` and it's child classes (`ImplicitRedisStorage` and
     `RedisS3Storage`) now supports `store_payload` and `get_payload` methods.
-- `Kind` enum to represent `result` and `payload` types.
-
-
-### Changed
-
-- `funcx_common.task_storage.RedisS3Storage`'s `_store_to_s3` and `_get_from_s3` method
-    signatures have been updated to use a `kind: {"result", "payload"}` option so that the
-    same method can be used for both results and payloads.
-

--- a/changelog.d/20211213_115038_yadudoc1729_add_payload_storage.md
+++ b/changelog.d/20211213_115038_yadudoc1729_add_payload_storage.md
@@ -1,0 +1,13 @@
+### Added
+
+- `funcx_common.task_storage.TaskStorage` and it's child classes (`ImplicitRedisStorage` and
+    `RedisS3Storage`) now supports `store_payload` and `get_payload` methods.
+- `Kind` enum to represent `result` and `payload` types.
+
+
+### Changed
+
+- `funcx_common.task_storage.RedisS3Storage`'s `_store_to_s3` and `_get_from_s3` method
+    signatures have been updated to use a `kind: {"result", "payload"}` option so that the
+    same method can be used for both results and payloads.
+

--- a/changelog.d/20211213_115038_yadudoc1729_add_payload_storage.md
+++ b/changelog.d/20211213_115038_yadudoc1729_add_payload_storage.md
@@ -2,12 +2,3 @@
 
 - `funcx_common.task_storage.TaskStorage` and its child classes (`ImplicitRedisStorage` and
     `RedisS3Storage`) now support `store_payload` and `get_payload` methods.
-- `Kind` enum to represent `result` and `payload` types.
-
-
-### Changed
-
-- `funcx_common.task_storage.RedisS3Storage`'s `_store_to_s3` and `_get_from_s3` method
-    signatures have been updated to use a `kind: {"result", "payload"}` option so that the
-    same method can be used for both results and payloads.
-

--- a/src/funcx_common/task_storage/base.py
+++ b/src/funcx_common/task_storage/base.py
@@ -32,3 +32,19 @@ class TaskStorage(abc.ABC):
         Returns a string if a result was found, and None otherwise.
         Raises a storage exception if retrieval failed
         """
+
+    @abc.abstractmethod
+    def store_payload(self, task: TaskProtocol, payload: str) -> None:
+        """
+        Store the payload of a task.
+        If the storage call succeeded, set reference to data in Task.payload_reference
+        If the storage failed, raises StorageException
+        """
+
+    @abc.abstractmethod
+    def get_payload(self, task: TaskProtocol) -> t.Optional[str]:
+        """
+        Get the task payload.
+        Returns a string if a payload was found, and None otherwise.
+        Raises a storage exception if retrieval failed
+        """

--- a/src/funcx_common/task_storage/redis.py
+++ b/src/funcx_common/task_storage/redis.py
@@ -24,3 +24,16 @@ class ImplicitRedisStorage(TaskStorage):
         if task.result:
             return task.result
         return None
+
+    def store_payload(
+        self,
+        task: TaskProtocol,
+        payload: str,
+    ) -> None:
+        task.payload = payload
+        task.payload_reference = {"storage_id": "redis"}
+
+    def get_payload(self, task: TaskProtocol) -> t.Optional[str]:
+        if task.payload:
+            return task.payload
+        return None

--- a/src/funcx_common/task_storage/s3.py
+++ b/src/funcx_common/task_storage/s3.py
@@ -1,4 +1,5 @@
 import typing as t
+from enum import Enum
 
 try:
     import boto3
@@ -11,6 +12,11 @@ except ImportError:
 from ..tasks import TaskProtocol
 from .base import StorageException, TaskStorage
 from .redis import ImplicitRedisStorage
+
+
+class Kind(Enum):
+    result = 1
+    payload = 2
 
 
 class RedisS3Storage(TaskStorage):
@@ -38,9 +44,11 @@ class RedisS3Storage(TaskStorage):
 
         self.redis_threshold = redis_threshold
         self.redis_storage = ImplicitRedisStorage()
+        self.storable_kinds = ("result", "payload")
 
-    def _store_to_s3(self, task: TaskProtocol, result: str) -> None:
-        key = f"{task.task_id}.result"
+    def _store_to_s3(self, task: TaskProtocol, kind: Kind, result: str) -> None:
+
+        key = f"{task.task_id}.{kind.name}"
         try:
             self.client.put_object(
                 Body=result.encode("utf-8"),
@@ -49,39 +57,41 @@ class RedisS3Storage(TaskStorage):
             )
         except botocore.exceptions.ClientError as err:
             raise StorageException(
-                f"Putting result into s3 for task:{task.task_id} failed"
+                f"Putting {kind.name} into s3 for task:{task.task_id} failed"
             ) from err
         else:
-            task.result_reference = {
+            reference = {
                 "storage_id": "s3",
                 "s3bucket": self.bucket_name,
                 "key": key,
             }
+            setattr(task, f"{kind.name}_reference", reference)
 
-    def _get_from_s3(self, task: TaskProtocol) -> str:
-        result_ref = task.result_reference
-        if result_ref is None:  # pragma: no cover
+    def _get_from_s3(self, task: TaskProtocol, kind: Kind) -> str:
+
+        reference = getattr(task, f"{kind.name}_reference")
+        if reference is None:  # pragma: no cover
             raise StorageException(
                 f"task {task.task_id} result reference was None inside of _get_from_s3"
             )
         try:
-            bucket = result_ref["s3bucket"]
-            key = result_ref["key"]
+            bucket = reference["s3bucket"]
+            key = reference["key"]
         except KeyError as err:
             raise StorageException(
-                "task {task.task_id} result_reference pointed to S3, but was missing "
-                "s3bucket or key"
+                f"task {task.task_id} {kind.name}_reference pointed to S3, "
+                "but was missing s3bucket or key"
             ) from err
 
         if not isinstance(bucket, str):
             raise StorageException(
-                "task {task.task_id} result_reference pointed to S3, "
+                f"task {task.task_id} {kind.name}_reference pointed to S3, "
                 f"but s3bucket was of type {type(bucket)} (expected string)"
             )
 
         if not isinstance(key, str):
             raise StorageException(
-                "task {task.task_id} result_reference pointed to S3, "
+                f"task {task.task_id} {kind.name}_reference pointed to S3, "
                 f"but key was of type {type(key)} (expected string)"
             )
 
@@ -101,7 +111,7 @@ class RedisS3Storage(TaskStorage):
     ) -> None:
         if len(result) > self.redis_threshold:
             # Task is too big for Redis, store in S3
-            self._store_to_s3(task, result)
+            self._store_to_s3(task, Kind.result, result)
         else:
             self.redis_storage.store_result(task, result)
 
@@ -119,7 +129,7 @@ class RedisS3Storage(TaskStorage):
 
         if task.result_reference:
             if task.result_reference["storage_id"] == "s3":
-                return self._get_from_s3(task)
+                return self._get_from_s3(task, Kind.result)
 
             # The following is redundant now while the block above
             # for backward compat exists
@@ -129,6 +139,41 @@ class RedisS3Storage(TaskStorage):
             else:
                 raise StorageException(
                     f"Unknown Storage requested: {task.result_reference}"
+                )
+        else:
+            return None
+
+    def store_payload(self, task: TaskProtocol, payload: str) -> None:
+        if len(payload) > self.redis_threshold:
+            # Task is too big for Redis, store in S3
+            self._store_to_s3(task, Kind.payload, payload)
+        else:
+            self.redis_storage.store_payload(task, payload)
+
+    def get_payload(self, task: TaskProtocol) -> t.Optional[str]:
+        """
+
+        :param task:
+        :return: Results payload if available, else returns None
+        Raises StorageException if fetching fails
+        """
+        # We should be able to safely remove the following block
+        # once all tasks launched with v0.3.3 and prior have TTL'ed out
+        if task.payload:
+            return task.payload
+
+        if task.payload_reference:
+            if task.payload_reference["storage_id"] == "s3":
+                return self._get_from_s3(task, Kind.payload)
+
+            # The following is redundant now while the block above
+            # for backward compat exists
+            # remove the pragma once this is an active codepath
+            elif task.payload_reference["storage_id"] == "redis":  # pragma: no cover
+                return self.redis_storage.get_payload(task)
+            else:
+                raise StorageException(
+                    f"Unknown Storage requested: {task.payload_reference}"
                 )
         else:
             return None

--- a/src/funcx_common/tasks/protocol.py
+++ b/src/funcx_common/tasks/protocol.py
@@ -15,3 +15,5 @@ class TaskProtocol:
     status: TaskState
     result: t.Optional[str]
     result_reference: t.Optional[t.Dict[str, t.Any]]
+    payload: t.Optional[str]
+    payload_reference: t.Optional[t.Dict[str, t.Any]]

--- a/tests/functional/storage/test_s3_functional.py
+++ b/tests/functional/storage/test_s3_functional.py
@@ -27,6 +27,8 @@ class SimpleInMemoryTask(TaskProtocol):
         self.status = TaskState.RECEIVED
         self.result = None
         self.result_reference = None
+        self.payload = None
+        self.payload_reference = None
 
 
 def test_s3_storage(funcx_s3_bucket):
@@ -42,16 +44,34 @@ def test_s3_storage(funcx_s3_bucket):
     assert task.result_reference["storage_id"] == "s3"
 
 
+def test_s3_storage_payload(funcx_s3_bucket):
+    """Confirm that data is stored to s3"""
+    # We are setting threshold of 0 to force only s3 storage
+    store = RedisS3Storage(bucket_name=funcx_s3_bucket, redis_threshold=0)
+    payload = "Hello World!"
+    task = SimpleInMemoryTask()
+
+    store.store_payload(task, payload)
+    assert store.get_payload(task) == payload
+    assert task.payload_reference
+    assert task.payload_reference["storage_id"] == "s3"
+
+
 def test_s3_storage_below_threshold(funcx_s3_bucket):
     """Confirm that data is NOT stored to s3"""
     store = RedisS3Storage(bucket_name=funcx_s3_bucket, redis_threshold=100)
-    result = "Hello World!"
+    data = "Hello World!"
     task = SimpleInMemoryTask()
 
-    store.store_result(task, result)
-    assert store.get_result(task) == result
+    store.store_result(task, data)
+    assert store.get_result(task) == data
     assert task.result_reference
     assert task.result_reference["storage_id"] == "redis"
+
+    store.store_payload(task, data)
+    assert store.get_payload(task) == data
+    assert task.payload_reference
+    assert task.payload_reference["storage_id"] == "redis"
 
     # ensure that S3 was not written with data for the task
     s3_client = boto3.client("s3")
@@ -67,17 +87,21 @@ def test_s3_storage_bad_bucket():
 
     # We are setting threshold of 0 to force only s3 storage
     store = RedisS3Storage(bucket_name=bucket_name, redis_threshold=0)
-    result = "Hello World!"
+    data = "Hello World!"
     task = SimpleInMemoryTask()
 
     with pytest.raises(StorageException):
-        store.store_result(task, result)
+        store.store_result(task, data)
+
+    with pytest.raises(StorageException):
+        store.store_payload(task, data)
 
     # because writing failed above, no exception will be seen when reading
     # to test that, we must either explicitly delete the task data or the bucket
     # after *successfully* storing the result
     # see the "deleted data" test below for that scenario
     assert store.get_result(task) is None
+    assert store.get_payload(task) is None
 
 
 def test_s3_storage_direct(funcx_s3_bucket):
@@ -88,6 +112,21 @@ def test_s3_storage_direct(funcx_s3_bucket):
     task = SimpleInMemoryTask()
 
     store.store_result(task, result)
+
+    s3_client = boto3.client("s3")
+    response = s3_client.list_objects(Bucket=funcx_s3_bucket, Prefix=task.task_id)
+    assert response["Contents"]
+    assert len(response["Contents"]) == 1
+
+
+def test_s3_storage_direct_payload(funcx_s3_bucket):
+    """Confirm that data is stored to s3 via boto3 for payloads"""
+    # We are setting threshold of 0 to force only s3 storage
+    store = RedisS3Storage(bucket_name=funcx_s3_bucket, redis_threshold=0)
+    data = "Hello World!"
+    task = SimpleInMemoryTask()
+
+    store.store_payload(task, data)
 
     s3_client = boto3.client("s3")
     response = s3_client.list_objects(Bucket=funcx_s3_bucket, Prefix=task.task_id)
@@ -110,6 +149,26 @@ def test_s3_storage_deleted_data(funcx_s3_bucket):
 
     with pytest.raises(StorageException) as excinfo:
         store.get_result(task)
+
+    err = excinfo.value
+    assert "Fetching object from S3 failed" in str(err)
+
+
+def test_s3_storage_deleted_payload(funcx_s3_bucket):
+    store = RedisS3Storage(bucket_name=funcx_s3_bucket, redis_threshold=0)
+    data = "Hello World!"
+    task = SimpleInMemoryTask()
+
+    store.store_payload(task, data)
+
+    # explicit delete from S3
+    s3_client = boto3.client("s3")
+    s3_client.delete_object(
+        Bucket=task.payload_reference["s3bucket"], Key=task.payload_reference["key"]
+    )
+
+    with pytest.raises(StorageException) as excinfo:
+        store.get_payload(task)
 
     err = excinfo.value
     assert "Fetching object from S3 failed" in str(err)

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -284,17 +284,17 @@ def test_internal(test_bucket_mock):
     result2 = "Hello World!"
     task1 = SimpleInMemoryTask()
     task2 = SimpleInMemoryTask()
-    from funcx_common.task_storage.s3 import Kind
+    from funcx_common.task_storage.s3 import StorageFieldName
 
-    store._store_to_s3(task1, Kind.payload, payload1)
-    store._store_to_s3(task1, Kind.result, result1)
-    store._store_to_s3(task2, Kind.payload, payload2)
-    store._store_to_s3(task2, Kind.result, result2)
+    store._store_to_s3(task1, StorageFieldName.payload, payload1)
+    store._store_to_s3(task1, StorageFieldName.result, result1)
+    store._store_to_s3(task2, StorageFieldName.payload, payload2)
+    store._store_to_s3(task2, StorageFieldName.result, result2)
 
-    assert store._get_from_s3(task1, Kind.payload) == payload1
-    assert store._get_from_s3(task1, Kind.result) == result1
-    assert store._get_from_s3(task2, Kind.payload) == payload2
-    assert store._get_from_s3(task2, Kind.result) == result2
+    assert store._get_from_s3(task1, StorageFieldName.payload) == payload1
+    assert store._get_from_s3(task1, StorageFieldName.result) == result1
+    assert store._get_from_s3(task2, StorageFieldName.payload) == payload2
+    assert store._get_from_s3(task2, StorageFieldName.result) == result2
 
 
 @pytest.mark.skipif(not has_boto, reason="test requires boto3 lib")

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -26,6 +26,8 @@ class SimpleInMemoryTask(TaskProtocol):
         self.status = TaskState.RECEIVED
         self.result = None
         self.result_reference = None
+        self.payload = None
+        self.payload_reference = None
 
 
 @pytest.fixture
@@ -139,6 +141,20 @@ def test_cannot_create_storage_without_boto3_lib(funcx_s3_bucket):
 
 
 @pytest.mark.skipif(not has_boto, reason="test requires boto3 lib")
+def test_s3_storage_simple_payload(test_bucket_mock):
+    """Confirm that payload data is stored to s3(mock)"""
+    # We are setting threshold of 0 to force only s3 storage
+    store = RedisS3Storage(bucket_name="funcx-test-1", redis_threshold=0)
+    payload = "Hello World!"
+    task = SimpleInMemoryTask()
+
+    store.store_payload(task, payload)
+    assert store.get_payload(task) == payload
+    assert task.payload_reference
+    assert task.payload_reference["storage_id"] == "s3"
+
+
+@pytest.mark.skipif(not has_boto, reason="test requires boto3 lib")
 def test_s3_storage_simple(test_bucket_mock):
     """Confirm that data is stored to s3(mock)"""
     # We are setting threshold of 0 to force only s3 storage
@@ -188,8 +204,10 @@ def test_differentiator(test_bucket_mock):
 def test_s3_task_with_invalid_reference(test_bucket_mock, storage_attrs):
     store = RedisS3Storage(bucket_name="funcx-test-1", redis_threshold=0)
 
+    payload = "Hello Payload"
     result = "Hello World!"
     task = SimpleInMemoryTask()
+    store.store_payload(task, payload)
     store.store_result(task, result)
 
     assert task.result_reference["storage_id"] == "s3"
@@ -201,6 +219,15 @@ def test_s3_task_with_invalid_reference(test_bucket_mock, storage_attrs):
 
     with pytest.raises(StorageException):
         store.get_result(task)
+
+    for key, action in storage_attrs.items():
+        if action["do"] == "del":
+            del task.payload_reference[key]
+        elif action["do"] == "set":
+            task.payload_reference[key] = action["val"]
+
+    with pytest.raises(StorageException):
+        store.get_payload(task)
 
 
 @pytest.mark.skipif(not has_boto, reason="test requires boto3 lib")
@@ -220,3 +247,65 @@ def test_task_with_unknown_storage(test_bucket_mock):
 def test_storage_exception_str():
     err = StorageException("foo")
     assert str(err).endswith("reason: foo")
+
+
+@pytest.mark.skipif(not has_boto, reason="test requires boto3 lib")
+def test_differentiator_payload(test_bucket_mock):
+    """Confirm that the threshold works to pick the right storage target
+    for payloads"""
+    # We are setting threshold of 0 to force only s3 storage
+    store = RedisS3Storage(bucket_name="funcx-test-1", redis_threshold=5)
+
+    payload1 = "Hi"
+    payload2 = "Hello World!"
+    task1 = SimpleInMemoryTask()
+    task2 = SimpleInMemoryTask()
+
+    store.store_payload(task1, payload1)
+    store.store_payload(task2, payload2)
+
+    assert store.get_payload(task1) == payload1
+    assert task1.payload == payload1
+    assert task1.payload_reference["storage_id"] == "redis"
+
+    assert store.get_payload(task2) == payload2
+    assert task2.payload_reference["storage_id"] == "s3"
+
+
+@pytest.mark.skipif(not has_boto, reason="test requires boto3 lib")
+def test_internal(test_bucket_mock):
+    """Test internal methods"""
+    # We are setting threshold of 0 to force only s3 storage
+    store = RedisS3Storage(bucket_name="funcx-test-1", redis_threshold=5)
+
+    payload1 = "Hi"
+    result1 = "Hi"
+    payload2 = "Hello World!"
+    result2 = "Hello World!"
+    task1 = SimpleInMemoryTask()
+    task2 = SimpleInMemoryTask()
+    from funcx_common.task_storage.s3 import Kind
+
+    store._store_to_s3(task1, Kind.payload, payload1)
+    store._store_to_s3(task1, Kind.result, result1)
+    store._store_to_s3(task2, Kind.payload, payload2)
+    store._store_to_s3(task2, Kind.result, result2)
+
+    assert store._get_from_s3(task1, Kind.payload) == payload1
+    assert store._get_from_s3(task1, Kind.result) == result1
+    assert store._get_from_s3(task2, Kind.payload) == payload2
+    assert store._get_from_s3(task2, Kind.result) == result2
+
+
+@pytest.mark.skipif(not has_boto, reason="test requires boto3 lib")
+def test_task_with_unknown_storage_for_payload(test_bucket_mock):
+    store = RedisS3Storage(bucket_name="funcx-test-1", redis_threshold=0)
+
+    result = "Hello World!"
+    task = SimpleInMemoryTask()
+    store.store_payload(task, result)
+    assert task.payload_reference["storage_id"] == "s3"
+    task.payload_reference["storage_id"] = "UnknownFakeStorageType"
+
+    with pytest.raises(StorageException):
+        store.get_payload(task)


### PR DESCRIPTION
This PR adds `get_payload` and `store_payload` methods to the `TaskStorage` classes.

This PR updates the `RedisS3Storage._store_to_s3` and `_get_from_s3` internal methods to use an enum (Kind: {payload, result}) since the accessors for both results and payloads are essentially the same. This is reflected in the new signature that takes a required arg: `kind`.