### PR TITLE
Add `RedisTask` implementation to library

### DIFF
--- a/changelog.d/20211220_204054_sirosen_add_redis_task.md
+++ b/changelog.d/20211220_204054_sirosen_add_redis_task.md
@@ -1,0 +1,9 @@
+### Added
+
+- A new class, `funcx_common.redis_task.RedisTask` has been added, which
+  implements the `TaskProtocol` backed with `RedisField` attributes. This
+  follows the pattern of existing implementations.
+- `RedisTask.load` is added as a classmethod for loading tasks from Redis with
+  the requirement that the task must exist in Redis
+- A new enum has been added, `funcx_common.tasks.InternalTaskState`, for
+  task `internal_status` values

--- a/src/funcx_common/redis_task.py
+++ b/src/funcx_common/redis_task.py
@@ -23,7 +23,7 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
 
     Creation:
       Create a new task by instantiating this class, e.g.
-      >>> RedisTask(reids_client, "foo_id")
+      >>> RedisTask(redis_client, "foo_id")
 
     Loading:
       Read a task from storage using the `load()` classmethod, e.g.
@@ -36,8 +36,8 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
       Traceback (most recent call last):
         ...
       ValueError: Cannot load task foo_id: does not exist
-      >>> RedisTask(reids_client, "foo_id")  # ok
-      >>> RedisTask(reids_client, "foo_id")
+      >>> RedisTask(redis_client, "foo_id")  # ok
+      >>> RedisTask(redis_client, "foo_id")
       Traceback (most recent call last):
         ...
       ValueError: Conflict. Cannot create task foo_id: already exists
@@ -60,14 +60,19 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
     # 2 weeks in seconds
     DEFAULT_TTL: t.ClassVar[int] = 1209600
 
+    # required fields
+    # TODO: when `required=True` is supported in `RedisField`, set it for all of these
     status = t.cast(TaskState, RedisField(serde=FuncxRedisEnumSerde(TaskState)))
     internal_status = t.cast(
         InternalTaskState, RedisField(serde=FuncxRedisEnumSerde(InternalTaskState))
     )
     user_id = t.cast(int, RedisField(serde=INT_SERDE))
-    function_id = t.cast(t.Optional[str], RedisField())
-    endpoint = t.cast(t.Optional[str], RedisField())
+    function_id = t.cast(str, RedisField())
     container = t.cast(str, RedisField())
+    task_group_id = t.cast(str, RedisField())
+    # end required fields
+
+    endpoint = t.cast(t.Optional[str], RedisField())
 
     # FIXME: `payload` is a string which is currently being round-tripped through the
     # JSON_SERDE. However, we cannot remove the use of the serde until we are prepared
@@ -94,7 +99,6 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
     )
     exception = t.cast(t.Optional[str], RedisField())
     completion_time = t.cast(t.Optional[str], RedisField())
-    task_group_id = t.cast(t.Optional[str], RedisField())
 
     def __init__(
         self,

--- a/src/funcx_common/redis_task.py
+++ b/src/funcx_common/redis_task.py
@@ -1,0 +1,184 @@
+import typing as t
+
+from .redis import (
+    INT_SERDE,
+    JSON_SERDE,
+    FuncxRedisEnumSerde,
+    HasRedisFieldsMeta,
+    RedisField,
+)
+from .tasks import InternalTaskState, TaskProtocol, TaskState
+
+try:
+    import redis
+
+    has_redis = True
+except ImportError:
+    has_redis = False
+
+
+class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
+    """
+    ORM-esque class to wrap access to properties of tasks.
+
+    Creation:
+      Create a new task by instantiating this class, e.g.
+      >>> RedisTask(reids_client, "foo_id")
+
+    Loading:
+      Read a task from storage using the `load()` classmethod, e.g.
+      >>> RedisTask.load(redis_client, "foo_id")
+
+    Creation and Loading will each check `RedisTask.exists` when invoked. If the task_id
+    already exists on creation, or does not exist on load, a ValueError will be raised.
+    For example:
+      >>> RedisTask.load(redis_client, "foo_id")
+      Traceback (most recent call last):
+        ...
+      ValueError: Cannot load task foo_id: does not exist
+      >>> RedisTask(reids_client, "foo_id")  # ok
+      >>> RedisTask(reids_client, "foo_id")
+      Traceback (most recent call last):
+        ...
+      ValueError: Conflict. Cannot create task foo_id: already exists
+
+    This class provides various task fields as descriptors via RedisField, and is
+    responsible for de/serializing various data from/to hstore in Redis.
+
+    There are several elements of this pattern of use which need to be fixed. It is
+    important to be aware of the following:
+    - there is currently no use of Redis transactions, so nothing is atomic
+    - Each time a field descriptor is accessed, it is read, returned, and discarded.
+      Reading a field multiple times, even in a single python statement, is vulnerable
+      to data races
+    - no field requirements or validity are enforced -- reading a field can raise an
+      error if bad data were written to Redis
+    - each field is read individually, which can be inefficient and inconsistent (vs
+      getall or setall semantics)
+    """
+
+    # 2 weeks in seconds
+    DEFAULT_TTL: t.ClassVar[int] = 1209600
+
+    status = t.cast(TaskState, RedisField(serde=FuncxRedisEnumSerde(TaskState)))
+    internal_status = t.cast(
+        InternalTaskState, RedisField(serde=FuncxRedisEnumSerde(InternalTaskState))
+    )
+    user_id = t.cast(int, RedisField(serde=INT_SERDE))
+    function_id = t.cast(t.Optional[str], RedisField())
+    endpoint = t.cast(t.Optional[str], RedisField())
+    container = t.cast(str, RedisField())
+
+    # FIXME: `payload` is a string which is currently being round-tripped through the
+    # JSON_SERDE. However, we cannot remove the use of the serde until we are prepared
+    # to handle the potential resulting errors. (Namely, that loading an old payload
+    # would break)
+    #
+    # consider:
+    #   >>> json.dumps("a")
+    #   '"a"'
+    #
+    # therefore, we need to at least try `json.loads` on the payload (or do a breaking
+    # change)
+    #
+    # alternatively, once `payload_reference` is populated on all tasks, we can use it
+    # to include a bool flag for how the field should be deserialized. This would
+    # require that the serde object itself have access to the payload_reference
+    payload = t.cast(t.Optional[str], RedisField(serde=JSON_SERDE))
+    payload_reference = t.cast(
+        t.Optional[t.Dict[str, t.Any]], RedisField(serde=JSON_SERDE)
+    )
+    result = t.cast(t.Optional[str], RedisField())
+    result_reference = t.cast(
+        t.Optional[t.Dict[str, t.Any]], RedisField(serde=JSON_SERDE)
+    )
+    exception = t.cast(t.Optional[str], RedisField())
+    completion_time = t.cast(t.Optional[str], RedisField())
+    task_group_id = t.cast(t.Optional[str], RedisField())
+
+    def __init__(
+        self,
+        redis_client: "redis.Redis[t.Any]",
+        task_id: str,
+        *,
+        user_id: t.Optional[int] = None,
+        function_id: t.Optional[str] = None,
+        container: t.Optional[str] = None,
+        payload: t.Optional[str] = None,
+        payload_reference: t.Optional[t.Dict[str, t.Any]] = None,
+        task_group_id: t.Optional[str] = None,
+    ):
+        """
+        If optional values are passed, then they will be written.
+
+        Otherwise, they will fetched from any existing task entry.
+        :param redis_client: Redis client for properties to get/set
+        :param task_id: UUID of the task, as str
+        :param user_id: ID of user to whom this task belongs
+        :param function_id: UUID of the function for this task, as str
+        :param container: UUID of container in which to run, as str
+        :param payload: serialized function + input data
+        :param task_group_id: UUID of task group that this task belongs to
+        """
+        # non-RedisField attributes of a RedisTask
+        self.hname = f"task_{task_id}"
+        self.redis_client = redis_client
+        self.task_id = task_id
+
+        # TODO: reject `RedisTask()` if the task_id already exists:
+        #   if RedisTask.exists(redis_client, task_id): raise ...
+
+        # if required attributes are not yet set, initialize them to their defaults
+        if self.status is None:
+            self.status = TaskState.WAITING_FOR_EP  # type: ignore[unreachable]
+        if self.internal_status is None:
+            self.internal_status = (  # type: ignore[unreachable]
+                InternalTaskState.INCOMPLETE
+            )
+
+        # remaining RedisField attributes
+        if user_id is not None:
+            self.user_id = user_id
+        if function_id is not None:
+            self.function_id = function_id
+        if container is not None:
+            self.container = container
+        if payload is not None:
+            self.payload = payload
+        if payload_reference is not None:
+            self.payload_reference = payload_reference
+        if task_group_id is not None:
+            self.task_group_id = task_group_id
+
+        self.ttl = self.DEFAULT_TTL
+
+    @property
+    def ttl(self) -> int:
+        return self.redis_client.ttl(self.hname)
+
+    @ttl.setter
+    def ttl(self, expiration: int) -> None:
+        """Expires task after expiration time, if not already set."""
+        ttl_val = self.redis_client.ttl(self.hname)
+        if ttl_val < 0 or expiration < ttl_val:
+            # expire was not already set
+            self.redis_client.expire(self.hname, expiration)
+
+    def delete(self) -> None:
+        """Removes this task from Redis, to be used after the result is gotten"""
+        self.redis_client.delete(self.hname)
+
+    @classmethod
+    def exists(cls, redis_client: "redis.Redis[t.Any]", task_id: str) -> bool:
+        """Check if a given task_id exists in Redis"""
+        return bool(redis_client.exists(f"task_{task_id}"))
+
+    @classmethod
+    def load(cls, redis_client: "redis.Redis[t.Any]", task_id: str) -> "RedisTask":
+        """
+        Load a task from storage. Raises a ValueError if the task is not found.
+        """
+        # TODO: This has a race condition. Encapsulate it in a transaction.
+        if not cls.exists(redis_client, task_id):
+            raise ValueError(f"Cannot load task {task_id}: does not exist")
+        return cls(redis_client, task_id)

--- a/src/funcx_common/tasks/__init__.py
+++ b/src/funcx_common/tasks/__init__.py
@@ -1,7 +1,8 @@
-from .constants import TaskState
+from .constants import InternalTaskState, TaskState
 from .protocol import TaskProtocol
 
 __all__ = (
     "TaskState",
+    "InternalTaskState",
     "TaskProtocol",
 )

--- a/src/funcx_common/tasks/constants.py
+++ b/src/funcx_common/tasks/constants.py
@@ -10,3 +10,8 @@ class TaskState(str, enum.Enum):
     RUNNING = "running"
     SUCCESS = "success"
     FAILED = "failed"
+
+
+class InternalTaskState(str, enum.Enum):
+    INCOMPLETE = "incomplete"
+    COMPLETE = "complete"

--- a/tests/unit/test_redis_task.py
+++ b/tests/unit/test_redis_task.py
@@ -1,0 +1,98 @@
+import uuid
+
+import pytest
+
+from funcx_common.redis_task import RedisTask
+from funcx_common.tasks import InternalTaskState, TaskState
+from funcx_common.testing import LOCAL_REDIS_REACHABLE
+
+try:
+    import redis
+
+    has_redis = True
+except ImportError:
+    has_redis = False
+
+if not has_redis or not LOCAL_REDIS_REACHABLE:
+    pytest.skip(
+        "these tests only run with access to local redis", allow_module_level=True
+    )
+
+
+@pytest.fixture
+def redis_client():
+    return redis.Redis("localhost", port=6379, decode_responses=True)
+
+
+@pytest.mark.parametrize(
+    "add_kwargs",
+    [
+        {},
+        {"user_id": 10, "function_id": "blah_id"},
+        {
+            "container": "blahblah_id",
+            "payload": "foo bar",
+            "payload_reference": {"storage_id": "redis"},
+        },
+        {"task_group_id": "foo_id"},
+    ],
+)
+def test_redis_task_create(redis_client, add_kwargs):
+    task_id = str(uuid.uuid1())
+    task = RedisTask(redis_client, task_id, **add_kwargs)
+
+    # required attributes are present and set
+    assert hasattr(task, "status")
+    assert task.status is not None
+    assert task.status == TaskState.WAITING_FOR_EP
+    assert hasattr(task, "internal_status")
+    assert task.internal_status is not None
+    assert task.internal_status == InternalTaskState.INCOMPLETE
+
+    # the TTL is close to the default (could be slightly lower)
+    assert (RedisTask.DEFAULT_TTL - task.ttl) < 1
+
+    # other attributes are None if not assigned, and otherwise have the value which was
+    # set
+    for attrname in [
+        "user_id",
+        "function_id",
+        "container",
+        "payload",
+        "payload_reference",
+        "task_group_id",
+    ]:
+        assert getattr(task, attrname) == add_kwargs.get(attrname)
+
+
+def test_redis_task_cannot_increase_ttl(redis_client):
+    task_id = str(uuid.uuid1())
+    task = RedisTask(redis_client, task_id)
+
+    # attempt to increase the TTL (this will not do anything)
+    task.ttl = RedisTask.DEFAULT_TTL * 2
+    # the TTL is close to the default (could be slightly lower)
+    assert (RedisTask.DEFAULT_TTL - task.ttl) < 1
+
+
+def test_redis_task_existece_and_deletion(redis_client):
+    task_id = str(uuid.uuid1())
+
+    task = RedisTask(redis_client, task_id)  # create
+    assert RedisTask.exists(redis_client, task_id)  # exists
+    task.delete()  # delete
+    assert not RedisTask.exists(redis_client, task_id)  # does not exist
+
+
+def test_redis_task_load(redis_client):
+    task_id = str(uuid.uuid1())
+
+    # no such task
+    with pytest.raises(ValueError):
+        RedisTask.load(redis_client, task_id)
+
+    RedisTask(redis_client, task_id)  # create
+
+    # load works
+    task = RedisTask.load(redis_client, task_id)
+    assert isinstance(task, RedisTask)

--- a/tests/unit/test_redis_task.py
+++ b/tests/unit/test_redis_task.py
@@ -75,7 +75,7 @@ def test_redis_task_cannot_increase_ttl(redis_client):
     assert (RedisTask.DEFAULT_TTL - task.ttl) < 1
 
 
-def test_redis_task_existece_and_deletion(redis_client):
+def test_redis_task_existence_and_deletion(redis_client):
     task_id = str(uuid.uuid1())
 
     task = RedisTask(redis_client, task_id)  # create


### PR DESCRIPTION
This is an implementation of the RedisTask class found in funcx-web-service, funcx-websocket-service, and funcx-forwarder

In order to do this, InternalTaskState must be added to the task package.

---

This is almost identical to existing implementations. A few key differences:
- Different `RedisTask` classes have different implementations of expiration setting. The `ttl` property replaces these.
- `RedisTask.load` is new, meant to codify the notion that the constructor is used for new tasks, and a different method is used for existing ones (rather than the constructor for both cases)
- All RedisFields are cast to the desired type, not just some to match the TaskProtocol

Once a transition is done, we could consider consolidating this with the `funcx_common.tasks` package and getting rid of `TaskProtocol`.