### PR TITLE
Moving MaxResultSizeExceeded exception from funcx_endpoint

### DIFF
--- a/changelog.d/20220107_152015_yadudoc1729_add_MaxResultSizeExceeded_exception.md
+++ b/changelog.d/20220107_152015_yadudoc1729_add_MaxResultSizeExceeded_exception.md
@@ -1,0 +1,7 @@
+### Added
+
+- A new exception class, `funcx_common.errors.MaxResultSizeExceeded` has been added.
+  This exception is raised by the funcx_worker when a task's result size exceeds the
+  supported limit of 10MB.
+
+

--- a/src/funcx_common/errors.py
+++ b/src/funcx_common/errors.py
@@ -1,0 +1,14 @@
+class MaxResultSizeExceeded(Exception):
+    """
+    Result produced by the function exceeds the maximum supported result size
+    threshold"""
+
+    def __init__(self, result_size: int, result_size_limit: int):
+        self.result_size = result_size
+        self.result_size_limit = result_size_limit
+
+    def __str__(self) -> str:
+        return (
+            f"Task result of {self.result_size}B exceeded current "
+            f"limit of {self.result_size_limit}B"
+        )


### PR DESCRIPTION
Moving over `MaxResultSizeExceeded` from `funcx-endpoint.executors.high_throughput.funcx_worker` to `funcx-common` to avoid a circular dependency between the sdk and the endpoint. With the exception defined here, both these components can import from here.

Related to [sc-10598]