### PR TITLE
Switch to using pypa's `build` tool

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -51,10 +51,10 @@ commands = scriv collect {posargs}
 [testenv:publish-release]
 skip_install = true
 deps = twine
-       wheel
+       build
 # clean the build dir before rebuilding
 whitelist_externals = rm
 commands_pre = rm -rf dist/
 commands =
-    python setup.py sdist bdist_wheel
+    python -m build
     twine upload dist/*


### PR DESCRIPTION
Rather than `setuptools` with the `wheel` hook, `build` promises more isolated and reproducible builds. It builds an sdist and then uses the sdist to build the wheel. It also respects pyproject.toml metadata and can therefore be used to drive builds with non-setuptools backends in the future.

---

We've had some issues with the behavior of `wheel` during builds of `globus-sdk`. I switched us over to `build` and have been happy with the result.

`build` is now the packaging tool used in the pypa packaging guide and several major packages (e.g. `pipx`) are already using it for their builds.