### PR TITLE
Update pre-commit config and apply

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,33 +1,33 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
-  rev: v4.0.1
+  rev: v4.1.0
   hooks:
     - id: check-merge-conflict
     - id: trailing-whitespace
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.3.1
+  rev: 0.10.2
   hooks:
     - id: check-github-workflows
 - repo: https://github.com/python/black
-  rev: 21.6b0
+  rev: 22.1.0
   hooks:
     - id: black
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
+- repo: https://github.com/pycqa/flake8
+  rev: 4.0.1
   hooks:
     - id: flake8
-      additional_dependencies: ['flake8-bugbear==21.4.3']
+      additional_dependencies: ['flake8-bugbear==22.1.11']
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.9.1
+  rev: 5.10.1
   hooks:
     - id: isort
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.19.4
+  rev: v2.31.0
   hooks:
     - id: pyupgrade
       args: ["--py36-plus"]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.902
+  rev: v0.931
   hooks:
     - id: mypy
       files: ^src/funcx_common/

--- a/src/funcx_common/messagepack/message_types/task.py
+++ b/src/funcx_common/messagepack/message_types/task.py
@@ -36,10 +36,8 @@ class Task(Message):
     def get_v0_body(self) -> bytes:
         if self.raw_buffer is None:
             self.raw_buffer = (
-                f"TID={self.task_id};CID={self.container_id};{self.task_buffer}".encode(
-                    "utf-8"
-                )
-            )
+                f"TID={self.task_id};CID={self.container_id};{self.task_buffer}"
+            ).encode()
         return self.raw_buffer
 
     @classmethod

--- a/tests/unit/test_messagepack.py
+++ b/tests/unit/test_messagepack.py
@@ -56,7 +56,7 @@ def test_can_manually_v0_get_and_load_task():
     assert task_obj.task_buffer == "some data"
 
     on_wire = task_obj.get_v0_body()
-    assert on_wire == f"TID={task_id};CID={container_id};some data".encode("utf-8")
+    assert on_wire == f"TID={task_id};CID={container_id};some data".encode()
 
     task_obj2 = Task.load_v0_body(on_wire)
     assert task_obj2.task_id == task_id
@@ -64,7 +64,7 @@ def test_can_manually_v0_get_and_load_task():
     assert task_obj2.task_buffer == "some data"
     assert (
         task_obj2.get_v0_body()
-        == f"TID={task_id};CID={container_id};some data".encode("utf-8")
+        == f"TID={task_id};CID={container_id};some data".encode()
     )
 
 
@@ -74,7 +74,7 @@ def test_can_pack_and_unpack_task_v0(v0_packer):
     task_obj = Task(task_id, container_id, "some data")
 
     on_wire = v0_packer.pack(task_obj)
-    payload = f"TID={task_id};CID={container_id};some data".encode("utf-8")
+    payload = f"TID={task_id};CID={container_id};some data".encode()
     header = get_v0_header(MessageType.TASK)
     assert on_wire == header + payload
 
@@ -183,9 +183,9 @@ def test_can_pack_and_unpack_resultsack_v0(v0_packer):
         (MessageType.TASK, b"foo;bar"),
         (MessageType.TASK, b"TID=;CID=;foo"),
         (MessageType.TASK, b";;foo"),
-        (MessageType.TASK, f"TID={ID_ZERO};CID=;foo".encode("utf-8")),
-        (MessageType.TASK, f"TID=;CID={ID_ZERO};foo".encode("utf-8")),
-        (MessageType.TASK, f"TID={ID_ZERO};CID={ID_ZERO}".encode("utf-8")),
+        (MessageType.TASK, f"TID={ID_ZERO};CID=;foo".encode()),
+        (MessageType.TASK, f"TID=;CID={ID_ZERO};foo".encode()),
+        (MessageType.TASK, f"TID={ID_ZERO};CID={ID_ZERO}".encode()),
         (MessageType.HEARTBEAT, b"foo"),
         (MessageType.MANAGER_STATUS_REPORT, b""),
         (MessageType.MANAGER_STATUS_REPORT, b"foo"),


### PR DESCRIPTION
Run `pre-commit auotupdate` and bump flake8-bugbear to latest.
pyupgrade now converts `encode("utf-8")` on string nodes to `encode()`, so several rewrites were applied.