### PR TITLE
Remove pre-commit from github actions, use pre-commit.ci instead

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,17 +6,13 @@ on:
   schedule:
     - cron: '0 4 * * 1'
 jobs:
-  lint:
+  mypy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-        with:
-          python-version: "3.10"
-      - name: install tox
-        run: python -m pip install -U tox
-      - name: lint
-        run: python -m tox -e lint,mypy
+      - run: python -m pip install tox
+      - run: python -m tox -e mypy
 
   test:
     strategy:
@@ -26,7 +22,7 @@ jobs:
         include:
           - os: macos-latest
             python-version: "3.10"
-    name: "Python ${{ matrix.python-version }} on ${{ matrix.os }} "
+    name: "py${{ matrix.python-version }} on ${{ matrix.os }} "
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -37,6 +33,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install tox
-        run: python -m pip install -U tox
+        run: python -m pip install tox
       - name: test
         run: python -m tox -e py,py-nodeps -- --cov-report="term-missing:skip-covered"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/funcx-faas/funcx-common/main.svg)](https://results.pre-commit.ci/latest/github/funcx-faas/funcx-common/main)
+
 # funcx-common
 
 This package contains common utilities for use across various funcX projects.


### PR DESCRIPTION
The trailing whitespace should be fixed automatically by pre-commit.ci , demonstrating the autofixing feature.

EDIT: Initially this PR only added the markdown link to the readme, to show autofixing. I realized it's better to also remove `tox -e lint` from GH Actions at the same time.