### PR TITLE
Add default MessagePacker to module constants

### DIFF
--- a/changelog.d/20220518_162312_sirosen.md
+++ b/changelog.d/20220518_162312_sirosen.md
@@ -1,0 +1,10 @@
+### Added
+
+- `funcx_common.messagepack` now provides a default `MessagePacker` instance,
+  created at import time. This also allows for `pack` and `unpack` methods to
+  be provided as functions from the package. The following names are now
+  available for import and use:
+
+  - `funcx_common.messagepack.DEFAULT_MESSAGE_PACKER`
+  - `funcx_common.messagepack.pack`
+  - `funcx_common.messagepack.unpack`

--- a/src/funcx_common/messagepack/__init__.py
+++ b/src/funcx_common/messagepack/__init__.py
@@ -1,10 +1,13 @@
 from .exceptions import InvalidMessageError, UnrecognizedProtocolVersion
 from .message_types import Message
-from .packer import MessagePacker
+from .packer import DEFAULT_MESSAGE_PACKER, MessagePacker, pack, unpack
 
 __all__ = (
     # main packing/unpacking interface
     "MessagePacker",
+    "DEFAULT_MESSAGE_PACKER",
+    "pack",
+    "unpack",
     # common base for messages
     "Message",
     # errors

--- a/src/funcx_common/messagepack/packer.py
+++ b/src/funcx_common/messagepack/packer.py
@@ -36,3 +36,8 @@ class MessagePacker:
                 f"message had unknown protocol version {protocol_version}"
             )
         return impl.unpack(buf)
+
+
+DEFAULT_MESSAGE_PACKER = MessagePacker()
+pack = DEFAULT_MESSAGE_PACKER.pack
+unpack = DEFAULT_MESSAGE_PACKER.unpack


### PR DESCRIPTION
Add a default instance of MessagePacker and expose its pack and unpack methods as functions of the module. As a result, calling code doesn't need to manage creation of additional objects. Just import and use the default. If, in a future version, a non-default MessagePacker is needed, the design around dispatch and protocol versions is still accessible.

---

I noticed that in a few places I was making additions to the effect of
```
from funcx_common.messagepack import MessagePacker

_PACKER = MessagePacker()

...

message = ...
_PACKER.pack(message)
```

There's really no need to do this if we just do the work once here.
A module-level constant `DEFALT_MESSAGE_PACKER` will be instantiated at import-time and then everything can use that.

I'd like to release this change as `funcx-common` v0.0.13 and then upgrade to using that.

@chris-janidlo, I've chosen you for review because you were going to get started on some related work. So this seems on-topic. If there are other related changes to `funcx_common.messagepack` which would be useful, we can either include them in v0.0.13 or do a follow-up release.