### PR TITLE
Add new optional Result timing attributes

### DIFF
--- a/changelog.d/20220518_231006_sirosen_result_exec_timing.md
+++ b/changelog.d/20220518_231006_sirosen_result_exec_timing.md
@@ -1,0 +1,7 @@
+### Added
+
+- `funcx_common.messagepack.message_types.Result` now supports two new
+  optional attributes: `exec_start_ms` and `exec_end_ms`, for execution timing
+  info in milliseconds since epoch.
+- `funcx_common.messagepack.message_types.Result` has a computed property
+  `exec_duration_ms` which takes `exec_end_ms - exec_start_ms`

--- a/src/funcx_common/messagepack/message_types/base.py
+++ b/src/funcx_common/messagepack/message_types/base.py
@@ -18,6 +18,15 @@ class Message(BaseModel):
     def message_type(self) -> str:
         return self.Meta.message_type
 
+    # common Config for all of our pydantic models
+    class Config:
+        # set this flag to allow underscore-prefixed attrs to be used rather than
+        # pydantic.PrivateAttr to declare instance variables on models which are
+        # not part of the serialized data
+        # see:
+        #   https://pydantic-docs.helpmanual.io/usage/models/#private-model-attributes
+        underscore_attrs_are_private = True
+
 
 # a handy class decorator for assigning fields to the internal Meta class
 # correctly subclasses any Meta which might be defined on a message type

--- a/src/funcx_common/messagepack/message_types/result.py
+++ b/src/funcx_common/messagepack/message_types/result.py
@@ -20,7 +20,20 @@ class Result(Message):
     task_id: uuid.UUID
     data: str
     error_details: t.Optional[ResultErrorDetails]
+    exec_start_ms: t.Optional[int]
+    exec_end_ms: t.Optional[int]
+    # storage for the computed property, "private" (meaning it will not appear in
+    # serialized data)
+    _exec_duration_ms: t.Optional[int] = None
 
     @property
     def is_error(self) -> bool:
         return self.error_details is not None
+
+    @property
+    def exec_duration_ms(self) -> t.Optional[int]:
+        if self._exec_duration_ms is None:
+            if self.exec_start_ms is None or self.exec_end_ms is None:
+                return None
+            self._exec_duration_ms = self.exec_end_ms - self.exec_start_ms
+        return self._exec_duration_ms


### PR DESCRIPTION
exec_start_ms and exec_end_ms are new 'int|None' fields on Result messages. exec_duration_ms is the computed difference with per-instance caching in an inner attribute (standard pattern).

In order to support this behavior, add a config option for pydantic to mark "underscore_attrs_are_private". This makes attributes with leading underscores hidden from the serialization and deserialization passes.

---

@ryanchard, since you were the original author of https://github.com/funcx-faas/funcx/commit/f2859a6b, I'm tagging you in as the reviewer for this.