### PR TITLE
Container id none

### DIFF
--- a/changelog.d/20220613_112245_chris_container_id_none.md
+++ b/changelog.d/20220613_112245_chris_container_id_none.md
@@ -1,0 +1,40 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+### Changed
+
+- `Task` messages no longer require `container_id`, in support of running tasks that don't require containers.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/funcx_common/messagepack/message_types/task.py
+++ b/src/funcx_common/messagepack/message_types/task.py
@@ -1,5 +1,4 @@
 import typing as t
-
 import uuid
 
 from .base import Message, meta

--- a/src/funcx_common/messagepack/message_types/task.py
+++ b/src/funcx_common/messagepack/message_types/task.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import uuid
 
 from .base import Message, meta
@@ -6,5 +8,5 @@ from .base import Message, meta
 @meta(message_type="task")
 class Task(Message):
     task_id: uuid.UUID
-    container_id: uuid.UUID
+    container_id: t.Optional[uuid.UUID]
     task_buffer: str

--- a/tests/unit/test_messagepack.py
+++ b/tests/unit/test_messagepack.py
@@ -167,9 +167,8 @@ def _required_arg_test_ids(param):
         (EPStatusReport, {"endpoint_id": ID_ZERO, "ep_status_report": {}}),
         # ManagerStatusReport requires: task_statuses
         (ManagerStatusReport, {}),
-        # Task requires: task_id, container_id, task_buffer
+        # Task requires: task_id, task_buffer
         (Task, {"container_id": ID_ZERO, "task_buffer": "foo data"}),
-        (Task, {"task_id": ID_ZERO, "task_buffer": "foo data"}),
         (Task, {"task_id": ID_ZERO, "container_id": ID_ZERO}),
         # TaskCancel requires: task_id
         (TaskCancel, {}),

--- a/tests/unit/test_messagepack.py
+++ b/tests/unit/test_messagepack.py
@@ -60,6 +60,23 @@ def crudely_pack_data(data):
             },
             None,
         ),
+        (
+            Task,
+            {
+                "task_id": uuid.UUID("058cf505-a09e-4af3-a5f2-eb2e931af141"),
+                "container_id": None,
+                "task_buffer": "foo data",
+            },
+            None,
+        ),
+        (
+            Task,
+            {
+                "task_id": uuid.UUID("058cf505-a09e-4af3-a5f2-eb2e931af141"),
+                "task_buffer": "foo data",
+            },
+            None,
+        ),
         (TaskCancel, {"task_id": ID_ZERO}, None),
         (
             Result,


### PR DESCRIPTION
This is to support the endpoint-level behavior of either running on a container (in which case `container_id` should be a valid UUID) or running on the endpoint's global python environment (in which case we don't need a UUID)