### PR TITLE
Add method for messagepack messages to assert type

### DIFF
--- a/changelog.d/20220613_195030_sirosen_messagepack_wrong_messagetype.md
+++ b/changelog.d/20220613_195030_sirosen_messagepack_wrong_messagetype.md
@@ -1,0 +1,8 @@
+### Added
+
+- A new error class has been added, `messagepack.WrongMessageTypeError`
+
+- All `messagepack.Message` objects now support a new method,
+  `assert_one_of_types`, which takes `Message` subclasses as arguments and
+  raises a `WrongMessageTypeError` if `isinstance(..., message_types)` does not
+  pass

--- a/src/funcx_common/messagepack/__init__.py
+++ b/src/funcx_common/messagepack/__init__.py
@@ -1,4 +1,8 @@
-from .exceptions import InvalidMessageError, UnrecognizedProtocolVersion
+from .exceptions import (
+    InvalidMessageError,
+    UnrecognizedProtocolVersion,
+    WrongMessageTypeError,
+)
 from .message_types import Message
 from .packer import DEFAULT_MESSAGE_PACKER, MessagePacker, pack, unpack
 
@@ -13,4 +17,5 @@ __all__ = (
     # errors
     "InvalidMessageError",
     "UnrecognizedProtocolVersion",
+    "WrongMessageTypeError",
 )

--- a/src/funcx_common/messagepack/exceptions.py
+++ b/src/funcx_common/messagepack/exceptions.py
@@ -13,7 +13,7 @@ class UnrecognizedProtocolVersion(InvalidMessageError):
     """
 
 
-class WrongMessageTypeError(ValueError):
+class WrongMessageTypeError(InvalidMessageError):
     """
     Raised when a message has its type asserted and the type does not match the code's
     expectations.

--- a/src/funcx_common/messagepack/exceptions.py
+++ b/src/funcx_common/messagepack/exceptions.py
@@ -11,3 +11,10 @@ class UnrecognizedProtocolVersion(InvalidMessageError):
     When attempting to unpack a message, found a protocol version which was not
     supported.
     """
+
+
+class WrongMessageTypeError(ValueError):
+    """
+    Raised when a message has its type asserted and the type does not match the code's
+    expectations.
+    """

--- a/src/funcx_common/messagepack/message_types/base.py
+++ b/src/funcx_common/messagepack/message_types/base.py
@@ -4,6 +4,8 @@ import typing as t
 
 from pydantic import BaseModel
 
+from ..exceptions import WrongMessageTypeError
+
 MT = t.TypeVar("MT", bound=t.Type["Message"])
 
 
@@ -26,6 +28,12 @@ class Message(BaseModel):
         # see:
         #   https://pydantic-docs.helpmanual.io/usage/models/#private-model-attributes
         underscore_attrs_are_private = True
+
+    def assert_one_of_types(self, *message_types: type[Message]) -> None:
+        if not isinstance(self, message_types):
+            raise WrongMessageTypeError(
+                f"expected {message_types} but got {type(self)}"
+            )
 
 
 # a handy class decorator for assigning fields to the internal Meta class

--- a/tests/unit/test_messagepack.py
+++ b/tests/unit/test_messagepack.py
@@ -8,6 +8,7 @@ import pytest
 from funcx_common.messagepack import (
     MessagePacker,
     UnrecognizedProtocolVersion,
+    WrongMessageTypeError,
     pack,
     unpack,
 )
@@ -434,3 +435,17 @@ def test_result_without_timing_info():
     assert nostart.exec_start_ms is None
     assert nostart.exec_end_ms == 25
     assert nostart.exec_duration_ms is None
+
+
+def test_messages_can_assert_type():
+    message = Task(task_id=ID_ZERO, container_id=ID_ZERO, task_buffer="foo")
+    # ok cases
+    message.assert_one_of_types(Task)
+    message.assert_one_of_types(Task, Result)
+    message.assert_one_of_types(Result, Task, EPStatusReport)
+
+    # failing cases
+    with pytest.raises(WrongMessageTypeError):
+        message.assert_one_of_types(Result, EPStatusReport)
+    with pytest.raises(WrongMessageTypeError):
+        message.assert_one_of_types()


### PR DESCRIPTION
This is a simple method for letting messages assert that they are one
of a known set of types and raise a nicely formatted error if the
assertion fails.

Unfortunately, this cannot be expressed in the type system in a clean
way at present. A TypeGuard cannot be defined as a union over a
sequence-type argument to a method.

We don't want to build fragile code which is based on stringized
annotations being ealuated at runtime, so for now this just focuses on
giving us the runtime safety which we'll care about in our
applications. Additional `assert` calls, `cast` calls, or
`type:ignore` comments can still be used to narrow types under type
checking.