### PR TITLE
Add status_log property to RedisTask.

### DIFF
--- a/changelog.d/20220714_165620_kevin_add_status_log_property_to_redistask.md
+++ b/changelog.d/20220714_165620_kevin_add_status_log_property_to_redistask.md
@@ -1,0 +1,5 @@
+### Added
+
+- Added a `.status_log` property to the RedisTask object.  The state log
+  requires an atomic append, so this cannot be implemented as another field in
+  the RedisTask hash.  Instead, it is implemented as a top-level array.


### PR DESCRIPTION
The state log requires an atomic append, so this can't be implemented as another field in the RedisTask hash.  Instead, make it a top-level array, with a key prefix of the hname.

One note is that the field will expire nominally some time (few seconds to a few hours) after the associated hash key because updates to the state log key update the EXPIRE time.  Rather than implement a much slower workaround (basically check it first, incurring additional roundtrips), just ignore having a precise TTL.  We can do much better when Redis v7 is put into production via the NX flag.