### PR TITLE
Add TaskTransition events to messages

### DIFF
--- a/changelog.d/20220812_153348_rchard_add_timing_info.md
+++ b/changelog.d/20220812_153348_rchard_add_timing_info.md
@@ -1,0 +1,5 @@
+### Added
+
+- A `TaskTransition` message type which is used in the Result, ManagerStatusReport, and EPStatusReport to record status events.
+- Execution-start and execution-end TaskState constants.
+- ActorName constants to represent the various entities in the system.

--- a/src/funcx_common/messagepack/message_types/__init__.py
+++ b/src/funcx_common/messagepack/message_types/__init__.py
@@ -6,6 +6,7 @@ from .manager_status_report import ManagerStatusReport
 from .result import Result, ResultErrorDetails
 from .task import Task
 from .task_cancel import TaskCancel
+from .task_transition import TaskTransition
 
 ALL_MESSAGE_CLASSES: t.Set[t.Type[Message]] = {
     EPStatusReport,
@@ -13,6 +14,7 @@ ALL_MESSAGE_CLASSES: t.Set[t.Type[Message]] = {
     Task,
     TaskCancel,
     Result,
+    TaskTransition,
 }
 
 __all__ = (
@@ -23,5 +25,6 @@ __all__ = (
     "TaskCancel",
     "Result",
     "ResultErrorDetails",
+    "TaskTransition",
     "ALL_MESSAGE_CLASSES",
 )

--- a/src/funcx_common/messagepack/message_types/ep_status_report.py
+++ b/src/funcx_common/messagepack/message_types/ep_status_report.py
@@ -2,6 +2,7 @@ import typing as t
 import uuid
 
 from .base import Message, meta
+from .task_transition import TaskTransition
 
 
 @meta(message_type="ep_status_report")
@@ -14,4 +15,4 @@ class EPStatusReport(Message):
 
     endpoint_id: uuid.UUID
     ep_status_report: t.Dict[str, t.Any]
-    task_statuses: t.Dict[str, t.Any]
+    task_statuses: t.Dict[str, TaskTransition]

--- a/src/funcx_common/messagepack/message_types/manager_status_report.py
+++ b/src/funcx_common/messagepack/message_types/manager_status_report.py
@@ -1,6 +1,7 @@
 import typing as t
 
 from .base import Message, meta
+from .task_transition import TaskTransition
 
 
 @meta(message_type="manager_status_report")
@@ -10,4 +11,4 @@ class ManagerStatusReport(Message):
     saying which tasks are now RUNNING.
     """
 
-    task_statuses: t.Dict[str, t.Any]
+    task_statuses: t.Dict[str, TaskTransition]

--- a/src/funcx_common/messagepack/message_types/result.py
+++ b/src/funcx_common/messagepack/message_types/result.py
@@ -5,6 +5,7 @@ import uuid
 
 import pydantic
 
+from ...tasks.constants import TaskState
 from .base import Message, meta
 
 
@@ -20,20 +21,8 @@ class Result(Message):
     task_id: uuid.UUID
     data: str
     error_details: t.Optional[ResultErrorDetails]
-    exec_start_ms: t.Optional[int]
-    exec_end_ms: t.Optional[int]
-    # storage for the computed property, "private" (meaning it will not appear in
-    # serialized data)
-    _exec_duration_ms: t.Optional[int] = None
+    statuses: t.Optional[t.List[t.Tuple[int, TaskState]]]
 
     @property
     def is_error(self) -> bool:
         return self.error_details is not None
-
-    @property
-    def exec_duration_ms(self) -> t.Optional[int]:
-        if self._exec_duration_ms is None:
-            if self.exec_start_ms is None or self.exec_end_ms is None:
-                return None
-            self._exec_duration_ms = self.exec_end_ms - self.exec_start_ms
-        return self._exec_duration_ms

--- a/src/funcx_common/messagepack/message_types/result.py
+++ b/src/funcx_common/messagepack/message_types/result.py
@@ -5,8 +5,8 @@ import uuid
 
 import pydantic
 
-from .task_transition import TaskTransition
 from .base import Message, meta
+from .task_transition import TaskTransition
 
 
 class ResultErrorDetails(pydantic.BaseModel):
@@ -21,7 +21,7 @@ class Result(Message):
     task_id: uuid.UUID
     data: str
     error_details: t.Optional[ResultErrorDetails]
-    transitions: t.Optional[t.List[TaskTransition]]
+    task_statuses: t.Optional[t.List[TaskTransition]]
 
     @property
     def is_error(self) -> bool:

--- a/src/funcx_common/messagepack/message_types/result.py
+++ b/src/funcx_common/messagepack/message_types/result.py
@@ -5,7 +5,7 @@ import uuid
 
 import pydantic
 
-from ...tasks.constants import ActorName, TaskState
+from .task_transition import TaskTransition
 from .base import Message, meta
 
 
@@ -21,7 +21,7 @@ class Result(Message):
     task_id: uuid.UUID
     data: str
     error_details: t.Optional[ResultErrorDetails]
-    statuses: t.Optional[t.List[t.Tuple[int, TaskState, ActorName]]]
+    transitions: t.Optional[t.List[TaskTransition]]
 
     @property
     def is_error(self) -> bool:

--- a/src/funcx_common/messagepack/message_types/result.py
+++ b/src/funcx_common/messagepack/message_types/result.py
@@ -5,7 +5,7 @@ import uuid
 
 import pydantic
 
-from ...tasks.constants import TaskState
+from ...tasks.constants import ActorName, TaskState
 from .base import Message, meta
 
 
@@ -21,7 +21,7 @@ class Result(Message):
     task_id: uuid.UUID
     data: str
     error_details: t.Optional[ResultErrorDetails]
-    statuses: t.Optional[t.List[t.Tuple[int, TaskState]]]
+    statuses: t.Optional[t.List[t.Tuple[int, TaskState, ActorName]]]
 
     @property
     def is_error(self) -> bool:

--- a/src/funcx_common/messagepack/message_types/task_transition.py
+++ b/src/funcx_common/messagepack/message_types/task_transition.py
@@ -1,0 +1,18 @@
+import typing as t
+
+from ...tasks.constants import ActorName, TaskState
+from .base import Message, meta
+
+
+@meta(message_type="task_transition")
+class TaskTransition(Message):
+    timestamp: int
+    state: TaskState
+    actor: ActorName
+
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {
+            "timestamp": self.timestamp,
+            "state": self.state.value,
+            "actor": self.actor.value,
+        }

--- a/src/funcx_common/tasks/__init__.py
+++ b/src/funcx_common/tasks/__init__.py
@@ -1,8 +1,9 @@
-from .constants import InternalTaskState, TaskState
+from .constants import ActorName, InternalTaskState, TaskState
 from .protocol import TaskProtocol
 
 __all__ = (
     "TaskState",
+    "ActorName",
     "InternalTaskState",
     "TaskProtocol",
 )

--- a/src/funcx_common/tasks/constants.py
+++ b/src/funcx_common/tasks/constants.py
@@ -17,3 +17,12 @@ class TaskState(str, enum.Enum):
 class InternalTaskState(str, enum.Enum):
     INCOMPLETE = "incomplete"
     COMPLETE = "complete"
+
+
+class ActorName(str, enum.Enum):
+    WORKER = "worker"
+    MANAGER = "manager"
+    INTERCHANGE = "interchange"
+    ENDPOINT = "endpoint"
+    RESULT_PROCESSOR = "result-processor"
+    WEB_SERVICE = "web-service"

--- a/src/funcx_common/tasks/constants.py
+++ b/src/funcx_common/tasks/constants.py
@@ -7,6 +7,8 @@ class TaskState(str, enum.Enum):
     WAITING_FOR_EP = "waiting-for-ep"  # while waiting for ep to accept/be online
     WAITING_FOR_NODES = "waiting-for-nodes"  # jobs are pending at the scheduler
     WAITING_FOR_LAUNCH = "waiting-for-launch"
+    EXEC_START = "execution-start"
+    EXEC_END = "execution-end"
     RUNNING = "running"
     SUCCESS = "success"
     FAILED = "failed"

--- a/src/funcx_common/tasks/constants.py
+++ b/src/funcx_common/tasks/constants.py
@@ -12,6 +12,8 @@ class TaskState(str, enum.Enum):
     RUNNING = "running"
     SUCCESS = "success"
     FAILED = "failed"
+    RESULT_RECEIVED = "result-received"
+    RESULT_ENQUEUED = "result-enqueued"
 
 
 class InternalTaskState(str, enum.Enum):


### PR DESCRIPTION
To capture endpoint and worker-level timing information (such as the execution start and end time of a function) we need to capture task transition events and report them back to the web service to be persisted. 

This PR adds:

1. A new `TaskTransition` message type that records: state_time, taskstate, actor, to identify when, what, and who for a status event. These task transitions are now included in the Result, ManagerStatusReport, and EPStatusReport.
2. Adds EXEC_START and EXEC_END TaskState constants to be used for recording task transitions.
3. Adds a new ActorName constant to represent the various entities in the system. This is used to record who creates an event.