### PR TITLE
Add `queue_name` field to RedisTask

### DIFF
--- a/changelog.d/20221006_233813_kevin_add_queue_name_to_redistask.md
+++ b/changelog.d/20221006_233813_kevin_add_queue_name_to_redistask.md
@@ -1,0 +1,5 @@
+### Added
+
+- Add `queue_name` field to `RedisTask`.  This specifies the name of the AMQP
+  queue where this task's result will be put or found.  If not set, this task's
+  result will not be placed into an AMQP queue.

--- a/src/funcx_common/redis_task.py
+++ b/src/funcx_common/redis_task.py
@@ -71,6 +71,7 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
     function_id = t.cast(str, RedisField())
     container = t.cast(str, RedisField())
     task_group_id = t.cast(str, RedisField())
+    queue_name = t.cast(str, RedisField())
     # end required fields
 
     endpoint = t.cast(t.Optional[str], RedisField())
@@ -112,6 +113,7 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
         payload: t.Optional[str] = None,
         payload_reference: t.Optional[t.Dict[str, t.Any]] = None,
         task_group_id: t.Optional[str] = None,
+        queue_name: t.Optional[str] = None,
     ):
         """
         If optional values are passed, then they will be written.
@@ -124,6 +126,7 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
         :param container: UUID of container in which to run, as str
         :param payload: serialized function + input data
         :param task_group_id: UUID of task group that this task belongs to
+        :param queue_name: name of AMQP queue where results will be sent
         """
         # non-RedisField attributes of a RedisTask
         self.hname = f"task_{task_id}"
@@ -155,6 +158,8 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
             self.payload_reference = payload_reference
         if task_group_id is not None:
             self.task_group_id = task_group_id
+        if queue_name is not None:
+            self.queue_name = queue_name
 
         self.ttl = self.DEFAULT_TTL
 

--- a/tests/unit/test_redis_task.py
+++ b/tests/unit/test_redis_task.py
@@ -41,6 +41,7 @@ def redis_client():
             "payload_reference": {"storage_id": "redis"},
         },
         {"task_group_id": "foo_id"},
+        {"queue_name": "foo_name"},
     ],
 )
 def test_redis_task_create(redis_client, add_kwargs):
@@ -67,6 +68,7 @@ def test_redis_task_create(redis_client, add_kwargs):
         "payload",
         "payload_reference",
         "task_group_id",
+        "queue_name",
     ]:
         assert getattr(task, attrname) == add_kwargs.get(attrname)
 


### PR DESCRIPTION
If set, the value of this field specifies to which queue the task result will be enqueued.  If not set, the ResultProcessor will not put the task result into a queue.

Related funcX PR: ["Heavy FuncXExecutor refactor" (#942)](https://github.com/funcx-faas/funcX/pull/942)