### PR TITLE
Bump version; prep for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.0.16'></a>
+## 0.0.16 (2022-10-11)
+
+### Added
+
+- Add `queue_name` field to `RedisTask`.  This specifies the name of the AMQP
+  queue where this task's result will be put or found.  If not set, this task's
+  result will not be placed into an AMQP queue.
+
+## 0.0.15 (2022-07-15)
+
+### Added
+
+- Added a `.status_log` property to the RedisTask object.  The state log
+  requires an atomic append, so this cannot be implemented as another field in
+  the RedisTask hash.  Instead, it is implemented as a top-level array.
+
 ## 0.0.14 (2022-06-13)
 
 ### Changed

--- a/changelog.d/20220714_165620_kevin_add_status_log_property_to_redistask.md
+++ b/changelog.d/20220714_165620_kevin_add_status_log_property_to_redistask.md
@@ -1,5 +1,0 @@
-### Added
-
-- Added a `.status_log` property to the RedisTask object.  The state log
-  requires an atomic append, so this cannot be implemented as another field in
-  the RedisTask hash.  Instead, it is implemented as a top-level array.

--- a/changelog.d/20221006_233813_kevin_add_queue_name_to_redistask.md
+++ b/changelog.d/20221006_233813_kevin_add_queue_name_to_redistask.md
@@ -1,5 +1,0 @@
-### Added
-
-- Add `queue_name` field to `RedisTask`.  This specifies the name of the AMQP
-  queue where this task's result will be put or found.  If not set, this task's
-  result will not be placed into an AMQP queue.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = funcx-common
-version = 0.0.15
+version = 0.0.16
 description = Common tools for funcX projects
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
- Releasing v0.0.16.
- Manually add v0.0.15 changelog tidbits, as was forgotten last go-round.