### PR TITLE
Add error codes and classes for batch submit size limits

### DIFF
--- a/changelog.d/20221115_120954_chris_batch_run_payload_limit_errors.md
+++ b/changelog.d/20221115_120954_chris_batch_run_payload_limit_errors.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added error codes and classes for when submissions to the web service's `batch_run` API are too large

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = funcx-common
-version = 0.0.19
+version = 0.0.20
 description = Common tools for funcX projects
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/funcx_common/response_errors/__init__.py
+++ b/src/funcx_common/response_errors/__init__.py
@@ -2,6 +2,7 @@ from .constants import HTTPStatusCode, ResponseErrorCode
 from .error_base import FuncxResponseError
 from .error_classes import (
     AuthGroupNotFound,
+    BatchRunTooLarge,
     ContainerNotFound,
     EndpointAccessForbidden,
     EndpointAlreadyRegistered,
@@ -25,6 +26,7 @@ from .error_classes import (
     TaskGroupAccessForbidden,
     TaskGroupNotFound,
     TaskNotFound,
+    TaskPayloadTooLarge,
     UserNotFound,
     UserUnauthenticated,
 )
@@ -59,4 +61,6 @@ __all__ = (
     "TaskNotFound",
     "UserNotFound",
     "UserUnauthenticated",
+    "BatchRunTooLarge",
+    "TaskPayloadTooLarge",
 )

--- a/src/funcx_common/response_errors/constants.py
+++ b/src/funcx_common/response_errors/constants.py
@@ -32,6 +32,8 @@ class ResponseErrorCode(IntEnum):
     INSUFFICIENT_AUTH_SCOPE = 24
     RESOURCE_LOCKED = 25
     RESOURCE_CONFLICT = 26
+    BATCH_RUN_TOO_LARGE = 27
+    TASK_PAYLOAD_TOO_LARGE = 28
 
 
 # a collection of the HTTP status error codes that the service would make use of
@@ -43,6 +45,7 @@ class HTTPStatusCode(IntEnum):
     NOT_FOUND = 404
     REQUEST_TIMEOUT = 408
     RESOURCE_CONFLICT = 409
+    PAYLOAD_TOO_LARGE = 413
     RESOURCE_LOCKED = 423
     TOO_MANY_REQUESTS = 429
     INTERNAL_SERVER_ERROR = 500

--- a/src/funcx_common/response_errors/error_classes.py
+++ b/src/funcx_common/response_errors/error_classes.py
@@ -356,3 +356,39 @@ class InsufficientAuthScope(FuncxResponseError):
     def __init__(self) -> None:
         self.error_args = []
         self.reason = "Insufficient scope for this action"
+
+
+class BatchRunTooLarge(FuncxResponseError):
+    """Raised when the size of the POST body sent to the batch_run API
+    exceeds our limits."""
+
+    code = ResponseErrorCode.BATCH_RUN_TOO_LARGE
+    http_status_code = HTTPStatusCode.PAYLOAD_TOO_LARGE
+
+    def __init__(self, payload_size: int, max_size: int):
+        self.error_args = [payload_size, max_size]
+        self.reason = (
+            "Batch submission is too large: "
+            + f"{payload_size} bytes > {max_size} bytes"
+        )
+
+
+class TaskPayloadTooLarge(FuncxResponseError):
+    """Raised when the payload of a task sent to the batch_run API
+    exceeds our limits."""
+
+    code = ResponseErrorCode.TASK_PAYLOAD_TOO_LARGE
+    http_status_code = HTTPStatusCode.PAYLOAD_TOO_LARGE
+
+    def __init__(
+        self,
+        task_group_id: str,
+        task_id: str,
+        payload_size: int,
+        max_size: int,
+    ):
+        self.error_args = [task_group_id, task_id, payload_size, max_size]
+        self.reason = (
+            f"Payload for task {task_id} in task group {task_group_id} is "
+            + f"too large: {payload_size} bytes > {max_size} bytes"
+        )


### PR DESCRIPTION
For [sc-19267]. Note that the error classes both accept a `max_size` parameter - the plan is to specify that in the web-service in the form of an environment variable or config setting (TBD).