### PR TITLE
Add exception to report that user is not authorized to submit builds to the container service.

### DIFF
--- a/src/funcx_common/response_errors/__init__.py
+++ b/src/funcx_common/response_errors/__init__.py
@@ -3,6 +3,7 @@ from .error_base import FuncxResponseError
 from .error_classes import (
     AuthGroupNotFound,
     BatchRunTooLarge,
+    ContainerBuildForbidden,
     ContainerNotFound,
     EndpointAccessForbidden,
     EndpointAlreadyRegistered,
@@ -37,6 +38,7 @@ __all__ = (
     "FuncxResponseError",
     "AuthGroupNotFound",
     "ContainerNotFound",
+    "ContainerBuildForbidden",
     "EndpointAccessForbidden",
     "EndpointAlreadyRegistered",
     "EndpointInUseError",

--- a/src/funcx_common/response_errors/constants.py
+++ b/src/funcx_common/response_errors/constants.py
@@ -34,6 +34,7 @@ class ResponseErrorCode(IntEnum):
     RESOURCE_CONFLICT = 26
     BATCH_RUN_TOO_LARGE = 27
     TASK_PAYLOAD_TOO_LARGE = 28
+    CONTAINER_SERVICE_NOT_PERMITTED = 29
 
 
 # a collection of the HTTP status error codes that the service would make use of

--- a/src/funcx_common/response_errors/error_classes.py
+++ b/src/funcx_common/response_errors/error_classes.py
@@ -151,6 +151,17 @@ class FunctionNotPermitted(FuncxResponseError):
         self.endpoint_uuid = endpoint_uuid
 
 
+class ContainerBuildForbidden(FuncxResponseError):
+    """User not entitled to use container service"""
+
+    code = ResponseErrorCode.CONTAINER_SERVICE_NOT_PERMITTED
+    http_status_code = HTTPStatusCode.FORBIDDEN
+
+    def __init__(self) -> None:
+        self.reason = "Unauthorized container service access"
+        self.error_args = [""]
+
+
 class EndpointAlreadyRegistered(FuncxResponseError):
     """Endpoint with specified uuid already registered by a different user"""
 


### PR DESCRIPTION
# Problem
We want to protect the container service from abuse by only allowing approved members access to build container. This PR adds a new exception to report back to the user if they are not permitted use the container service.

# Approach
Add a new Exception class and associated error code