### PR TITLE
Add container info to Task structure

### DIFF
--- a/changelog.d/20230120_150207_kevin_add_container_location_to_task.md
+++ b/changelog.d/20230120_150207_kevin_add_container_location_to_task.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Container information can now be conveyed directly with Task messages, not just ``container_id``
+

--- a/src/funcx_common/messagepack/message_types/__init__.py
+++ b/src/funcx_common/messagepack/message_types/__init__.py
@@ -1,6 +1,7 @@
 import typing as t
 
 from .base import Message
+from .container import Container, ContainerImage
 from .ep_status_report import EPStatusReport
 from .manager_status_report import ManagerStatusReport
 from .result import Result, ResultErrorDetails
@@ -9,6 +10,8 @@ from .task_cancel import TaskCancel
 from .task_transition import TaskTransition
 
 ALL_MESSAGE_CLASSES: t.Set[t.Type[Message]] = {
+    Container,
+    ContainerImage,
     EPStatusReport,
     ManagerStatusReport,
     Task,
@@ -19,6 +22,8 @@ ALL_MESSAGE_CLASSES: t.Set[t.Type[Message]] = {
 
 __all__ = (
     "Message",
+    "Container",
+    "ContainerImage",
     "EPStatusReport",
     "ManagerStatusReport",
     "Task",

--- a/src/funcx_common/messagepack/message_types/container.py
+++ b/src/funcx_common/messagepack/message_types/container.py
@@ -1,0 +1,21 @@
+import typing as t
+import uuid
+
+from .base import Message, meta
+
+
+@meta(message_type="containerimage")
+class ContainerImage(Message):
+    image_type: str  # e.g., (as currently envisioned), 'docker', 'singularity'
+    location: str  # location or name required to pull the image (e.g., python:3.10)
+    created_at: int
+    modified_at: int
+    build_status: t.Optional[str]
+    build_stderr: t.Optional[str]
+
+
+@meta(message_type="container")
+class Container(Message):
+    container_id: uuid.UUID
+    name: str
+    images: t.List[ContainerImage]

--- a/src/funcx_common/messagepack/message_types/task.py
+++ b/src/funcx_common/messagepack/message_types/task.py
@@ -2,10 +2,16 @@ import typing as t
 import uuid
 
 from .base import Message, meta
+from .container import Container
 
 
 @meta(message_type="task")
 class Task(Message):
     task_id: uuid.UUID
+
+    # for backward compatibility; to be removed when we support only
+    # endpoints >= v1.1
     container_id: t.Optional[uuid.UUID]
+
+    container: t.Optional[Container]
     task_buffer: str

--- a/tests/unit/test_messagepack.py
+++ b/tests/unit/test_messagepack.py
@@ -13,6 +13,7 @@ from funcx_common.messagepack import (
     unpack,
 )
 from funcx_common.messagepack.message_types import (
+    Container,
     EPStatusReport,
     ManagerStatusReport,
     Result,
@@ -99,10 +100,19 @@ def crudely_pack_data(data):
             None,
         ),
         (
+            Container,
+            {"container_id": uuid.uuid4(), "name": "some container name", "images": []},
+            None,
+        ),
+        (
             Task,
             {
                 "task_id": uuid.UUID("058cf505-a09e-4af3-a5f2-eb2e931af141"),
-                "container_id": uuid.UUID("f72b4570-8273-4913-a6a0-d77af864beb1"),
+                "container": Container(
+                    container_id=uuid.UUID("f72b4570-8273-4913-a6a0-d77af864beb1"),
+                    name="Some Container",
+                    images=[],
+                ),
                 "task_buffer": "foo data",
             },
             None,
@@ -111,7 +121,7 @@ def crudely_pack_data(data):
             Task,
             {
                 "task_id": uuid.UUID("058cf505-a09e-4af3-a5f2-eb2e931af141"),
-                "container_id": None,
+                "container": None,
                 "task_buffer": "foo data",
             },
             None,


### PR DESCRIPTION
It's optional, but enable more than a container_id to passed along with the task.