### PR TITLE
add constants for action provider log entries

### DIFF
--- a/src/funcx_common/tasks/constants.py
+++ b/src/funcx_common/tasks/constants.py
@@ -14,6 +14,11 @@ class TaskState(str, enum.Enum):
     FAILED = "failed"
     RESULT_RECEIVED = "result-received"
     RESULT_ENQUEUED = "result-enqueued"
+    AP_RECEIVED = "action-provider-received"
+    AP_TASK_SUBMITTED = "action-provider-task-submitted"
+    AP_TASKGROUP_RUNNING = "action-provider-task-group-in-progress"
+    AP_TASKGROUP_COMPLETED = "action-provider-task-group-completed"
+    AP_TASKGROUP_ERROR = "action-provider-task-group-error"
 
 
 class InternalTaskState(str, enum.Enum):
@@ -28,3 +33,4 @@ class ActorName(str, enum.Enum):
     ENDPOINT = "endpoint"
     RESULT_PROCESSOR = "result-processor"
     WEB_SERVICE = "web-service"
+    ACTION_PROVIDER = "action-provider"


### PR DESCRIPTION
Some constants to use for logging output in extra_logging for the new Action Provider.

Not all may be used, but better to put them in for now as fx_common needs to be available first