### PR TITLE
`EPStatusReport` - rename `ep_status_report` field to `global_state`

### DIFF
--- a/changelog.d/20230303_141732_chris_rename_ep_status_report_field.md
+++ b/changelog.d/20230303_141732_chris_rename_ep_status_report_field.md
@@ -1,0 +1,6 @@
+### Changed
+
+- Renamed the ``ep_status_report`` field of the ``EPStatusReport`` message to
+  ``global_state``
+
+  - ``global_state`` has an alias of ``ep_status_report`` for backward compatibility

--- a/src/funcx_common/messagepack/message_types/ep_status_report.py
+++ b/src/funcx_common/messagepack/message_types/ep_status_report.py
@@ -1,6 +1,8 @@
 import typing as t
 import uuid
 
+from pydantic import Field
+
 from .base import Message, meta
 from .task_transition import TaskTransition
 
@@ -14,5 +16,8 @@ class EPStatusReport(Message):
     """
 
     endpoint_id: uuid.UUID
-    ep_status_report: t.Dict[str, t.Any]
+    global_state: t.Dict[str, t.Any] = Field(alias="ep_status_report")
     task_statuses: t.Dict[str, t.List[TaskTransition]]
+
+    class Config:
+        allow_population_by_field_name = True

--- a/tests/unit/test_messagepack.py
+++ b/tests/unit/test_messagepack.py
@@ -39,21 +39,21 @@ def crudely_pack_data(data):
             EPStatusReport,
             {
                 "endpoint_id": uuid.UUID("058cf505-a09e-4af3-a5f2-eb2e931af141"),
-                "ep_status_report": {},
+                "global_state": {},
                 "task_statuses": {},
             },
             None,
         ),
         (
             EPStatusReport,
-            {"endpoint_id": ID_ZERO, "ep_status_report": {}, "task_statuses": {}},
+            {"endpoint_id": ID_ZERO, "global_state": {}, "task_statuses": {}},
             None,
         ),
         (
             EPStatusReport,
             {
                 "endpoint_id": ID_ZERO,
-                "ep_status_report": {
+                "global_state": {
                     str(ID_ZERO): [
                         TaskTransition(
                             timestamp=1,
@@ -70,7 +70,7 @@ def crudely_pack_data(data):
             EPStatusReport,
             {
                 "endpoint_id": ID_ZERO,
-                "ep_status_report": {},
+                "global_state": {},
                 "task_statuses": {
                     str(ID_ZERO): [
                         TaskTransition(
@@ -82,6 +82,11 @@ def crudely_pack_data(data):
                 },
             },
             None,
+        ),
+        (  # ep_status_report is an alias for global_state
+            EPStatusReport,
+            {"endpoint_id": ID_ZERO, "ep_status_report": {}, "task_statuses": {}},
+            {"endpoint_id": ID_ZERO, "global_state": {}, "task_statuses": {}},
         ),
         (ManagerStatusReport, {"task_statuses": {}}, None),
         (
@@ -244,9 +249,12 @@ def _required_arg_test_ids(param):
 @pytest.mark.parametrize(
     "message_class, init_args",
     [
-        # EPStatusReport requires: endpoint_id, ep_status_report, task_statuses
+        # EPStatusReport requires:
+        #   endpoint_id, global_state OR ep_status_report, task_statuses
+        (EPStatusReport, {"global_state": {}, "task_statuses": {}}),
         (EPStatusReport, {"ep_status_report": {}, "task_statuses": {}}),
         (EPStatusReport, {"endpoint_id": ID_ZERO, "task_statuses": {}}),
+        (EPStatusReport, {"endpoint_id": ID_ZERO, "global_state": {}}),
         (EPStatusReport, {"endpoint_id": ID_ZERO, "ep_status_report": {}}),
         # ManagerStatusReport requires: task_statuses
         (ManagerStatusReport, {}),


### PR DESCRIPTION
Having a field named `ep_status_report` as part of the `EPStatusReport` message can be confusing and isn't particularly accurate. `global_state` was chosen to differentiate the field from the task-specific EP status contained in `task_statuses`.

[sc-22365]