### PR TITLE
Add `allowlist_externals` in addition to `whitelist_externals` in `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ deps = twine
        build
 # clean the build dir before rebuilding
 whitelist_externals = rm
+allowist_externals = rm
 commands_pre = rm -rf dist/
 commands =
     python -m build


### PR DESCRIPTION
While rebuilding my local dev env following the compte rebranding, I installed the latest `tox`, which seems to completely ignore the old `whitelist_externals` field in favor of `allowlist_externals`.

This update fixes the issue by adding an additional field.