### PR TITLE
Quash messagepack warning

### DIFF
--- a/src/globus_compute_common/messagepack/protocol_versions/proto1.py
+++ b/src/globus_compute_common/messagepack/protocol_versions/proto1.py
@@ -88,7 +88,12 @@ def _log_unknown_fields(model: type[_ModelT], data: dict[str, t.Any]) -> None:
         raise NotImplementedError
 
     model_ = t.cast("type[pydantic.BaseModel]", model)
-    unknown_fields = {x for x in data if x not in model_.__fields__}
+
+    unknown_fields = set(data)
+    for name, field in model_.__fields__.items():
+        unknown_fields.discard(name)
+        unknown_fields.discard(field.alias)
+
     if unknown_fields:
         log.warning(
             "encountered unknown %s fields while reading a %s message: %s",

--- a/tests/unit/test_messagepack.py
+++ b/tests/unit/test_messagepack.py
@@ -415,11 +415,32 @@ def test_unknown_data_fields_warn(caplog):
         # successfully unpacked
         assert isinstance(msg, Task)
     # but logged a warning (do two assertions so as not to insist on a precise format
-    # for the logged fields
+    # for the logged fields)
     assert (
         "encountered unknown data fields while reading a task message:"
     ) in caplog.text
     assert "foo_field" in caplog.text
+
+
+def test_dont_warn_alias_fields(caplog):
+    buf = crudely_pack_data(
+        {
+            "message_type": "ep_status_report",
+            "data": {
+                "endpoint_id": str(ID_ZERO),
+                "ep_status_report": {"this is an alias": "for global_state"},
+                "task_statuses": [],
+            },
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="globus_compute_common"):
+        msg = unpack(buf)
+        # successfully unpacked
+        assert isinstance(msg, EPStatusReport)
+    # but logged no warning (do two assertions so as not to insist on a precise format
+    # for the logged fields)
+    assert "encountered unknown data fields" not in caplog.text
+    assert "ep_status_report" not in caplog.text
 
 
 def test_unknown_envelope_fields_warn(caplog):
@@ -439,7 +460,7 @@ def test_unknown_envelope_fields_warn(caplog):
         # successfully unpacked
         assert isinstance(msg, Task)
     # but logged a warning (do two assertions so as not to insist on a precise format
-    # for the logged fields
+    # for the logged fields)
     assert (
         "encountered unknown envelope fields while reading a task message:"
     ) in caplog.text


### PR DESCRIPTION
Messagepack has been issuing the following warning when unpacking `EPStatusReport` messages:

```
encountered unknown data fields while reading a ep_status_report message: {'ep_status_report'}
```

This is because the field `ep_status_report` was [recently renamed](https://github.com/funcx-faas/funcx-common/pull/78) to `global_state`. In order to preserve backward-compatibility, the old `ep_status_report` name was kept as an alias of the new `global_state` field, however messagepack didn't know that fields could be referred to by their alias.