### PR TITLE
Add metadata to Result class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.3.0a1'></a>
+## 0.3.0a1 (2023-08-07)
+
+### Changed
+
+- Added metadata dict to Result message
+- Added details dict to RedisTask
+
 <a id='changelog-0.2.0'></a>
 ## 0.2.0 (2023-05-10)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = globus-compute-common
-version = 0.2.0
+version = 0.3.0a2
 description = Common tools for Globus Compute projects
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/globus_compute_common/messagepack/message_types/result.py
+++ b/src/globus_compute_common/messagepack/message_types/result.py
@@ -17,18 +17,6 @@ class ResultErrorDetails(pydantic.BaseModel):
 
 
 @meta(message_type="result")
-class ResultV1(Message):
-    task_id: uuid.UUID
-    data: str
-    error_details: t.Optional[ResultErrorDetails]
-    task_statuses: t.Optional[t.List[TaskTransition]]
-
-    @property
-    def is_error(self) -> bool:
-        return self.error_details is not None
-
-
-@meta(message_type="result")
 class Result(Message):
     task_id: uuid.UUID
     data: str

--- a/src/globus_compute_common/messagepack/message_types/result.py
+++ b/src/globus_compute_common/messagepack/message_types/result.py
@@ -17,9 +17,22 @@ class ResultErrorDetails(pydantic.BaseModel):
 
 
 @meta(message_type="result")
+class ResultV1(Message):
+    task_id: uuid.UUID
+    data: str
+    error_details: t.Optional[ResultErrorDetails]
+    task_statuses: t.Optional[t.List[TaskTransition]]
+
+    @property
+    def is_error(self) -> bool:
+        return self.error_details is not None
+
+
+@meta(message_type="result")
 class Result(Message):
     task_id: uuid.UUID
     data: str
+    details: t.Optional[t.Dict[t.Any, t.Any]]
     error_details: t.Optional[ResultErrorDetails]
     task_statuses: t.Optional[t.List[TaskTransition]]
 

--- a/src/globus_compute_common/messagepack/protocol.py
+++ b/src/globus_compute_common/messagepack/protocol.py
@@ -7,7 +7,6 @@ A MessagePackProtocol only needs to define two actions:
 
 And the two must be inverses on any valid inputs.
 """
-
 import abc
 
 from .message_types import Message

--- a/src/globus_compute_common/messagepack/protocol.py
+++ b/src/globus_compute_common/messagepack/protocol.py
@@ -7,6 +7,7 @@ A MessagePackProtocol only needs to define two actions:
 
 And the two must be inverses on any valid inputs.
 """
+
 import abc
 
 from .message_types import Message

--- a/src/globus_compute_common/redis_task.py
+++ b/src/globus_compute_common/redis_task.py
@@ -99,6 +99,7 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
     result_reference = t.cast(
         t.Optional[t.Dict[str, t.Any]], RedisField(serde=JSON_SERDE)
     )
+    details = t.cast(t.Optional[t.Dict[str, t.Any]], RedisField(serde=JSON_SERDE))
     exception = t.cast(t.Optional[str], RedisField())
     completion_time = t.cast(t.Optional[str], RedisField())
 
@@ -115,6 +116,7 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
         task_group_id: t.Optional[str] = None,
         queue_name: t.Optional[str] = None,
         endpoint_id: t.Optional[str] = None,
+        details: t.Optional[t.Dict[str, t.Any]] = None,
     ):
         """
         If optional values are passed, then they will be written.
@@ -164,6 +166,8 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
             self.queue_name = queue_name
         if endpoint_id is not None:
             self.endpoint_id = endpoint_id
+        if details is not None:
+            self.details = details
 
         self.ttl = self.DEFAULT_TTL
 

--- a/tests/unit/test_messagepack.py
+++ b/tests/unit/test_messagepack.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import typing as t
 import uuid
 
 import pydantic
@@ -23,9 +24,6 @@ from globus_compute_common.messagepack.message_types import (
     TaskTransition,
 )
 from globus_compute_common.messagepack.message_types.base import Message, meta
-
-# Singular import of old Result class
-from globus_compute_common.messagepack.message_types.result import ResultV1
 from globus_compute_common.messagepack.protocol_versions.proto1 import (
     MessageEnvelope,
     _load,
@@ -33,6 +31,23 @@ from globus_compute_common.messagepack.protocol_versions.proto1 import (
 from globus_compute_common.tasks.constants import ActorName, TaskState
 
 ID_ZERO = uuid.UUID(int=0)
+
+
+@meta(message_type="result")
+class ResultV1(Message):
+    """
+    Old Result before 'details' field was added, for backwards compatibility
+    testing
+    """
+
+    task_id: uuid.UUID
+    data: str
+    error_details: t.Optional[ResultErrorDetails]
+    task_statuses: t.Optional[t.List[TaskTransition]]
+
+    @property
+    def is_error(self) -> bool:
+        return self.error_details is not None
 
 
 def crudely_pack_data(data):

--- a/tests/unit/test_messagepack.py
+++ b/tests/unit/test_messagepack.py
@@ -23,6 +23,13 @@ from globus_compute_common.messagepack.message_types import (
     TaskTransition,
 )
 from globus_compute_common.messagepack.message_types.base import Message, meta
+
+# Singular import of old Result class
+from globus_compute_common.messagepack.message_types.result import ResultV1
+from globus_compute_common.messagepack.protocol_versions.proto1 import (
+    MessageEnvelope,
+    _load,
+)
 from globus_compute_common.tasks.constants import ActorName, TaskState
 
 ID_ZERO = uuid.UUID(int=0)
@@ -235,6 +242,84 @@ def test_pack_and_unpack(message_class, init_args, expect_values, protocol_versi
         # otherwise, you get a false-negative when comparing `{"foo": "bar"}` to a
         # pydantic model object which `dict`s into `{"foo": "bar"}`
         assert type(v2) == type(v)  # noqa: E721
+
+
+@pytest.mark.parametrize(
+    "orig_class, new_class, init_args, expect_values",
+    [
+        (
+            # New version of Result will be deserialized by old unpack
+            Result,
+            ResultV1,
+            {
+                "task_id": ID_ZERO,
+                "data": "foo-bar-baz",
+                "metadata": {"a": "b"},
+            },
+            {
+                "task_id": ID_ZERO,
+                "data": "foo-bar-baz",
+            },
+        ),
+        (
+            # Old version of Result will be deserialized by new unpack
+            ResultV1,
+            Result,
+            {
+                "task_id": ID_ZERO,
+                "data": "d",
+                "error_details": ResultErrorDetails(code="c", user_message="m"),
+            },
+            {
+                "task_id": ID_ZERO,
+                "data": "d",
+                "edcode": "c",
+            },
+        ),
+        (
+            # Pre-serialized old version of Result is unpacked correctly
+            None,
+            Result,
+            b'\x01{"message_type":"result","data":{"task_id":"00000000-0000-0000-0000-000000000000","data":"d","error_details":{"code":"c","user_message":"m"},"task_statuses":null}}',  # noqa: E501
+            {
+                "task_id": ID_ZERO,
+                "data": "d",
+                "edcode": "c",
+            },
+        ),
+    ],
+)
+def test_result_back_compat(orig_class, new_class, init_args, expect_values):
+    packer = MessagePacker(default_protocol_version=1)
+    do_pack = packer.pack
+
+    def test_unpack(buf: bytes, force_class) -> Message:
+        body = buf[1:]
+        payload = json.loads(body)
+        envelope = _load(MessageEnvelope, payload)
+        return _load(force_class, envelope.data)
+
+    do_unpack = test_unpack
+
+    if orig_class is None:
+        on_wire = init_args
+    else:
+        message_obj = orig_class(**init_args)
+        on_wire = do_pack(message_obj)
+
+    unpacked_msg = do_unpack(on_wire, new_class)
+
+    assert isinstance(unpacked_msg, new_class)
+    assert unpacked_msg.task_id == expect_values["task_id"]
+    assert unpacked_msg.data == expect_values["data"]
+    if "edcode" in expect_values:
+        assert unpacked_msg.error_details.code == expect_values["edcode"]
+
+    # Either the new Result's metadata is discarded when serialized
+    #  by old package, or old Result is deserialized into a new one
+    #  without the info
+    if "metadata" not in expect_values:
+        assert not hasattr(unpacked_msg, "metadata")
 
 
 def _required_arg_test_ids(param):

--- a/tests/unit/test_redis_task.py
+++ b/tests/unit/test_redis_task.py
@@ -42,6 +42,16 @@ def redis_client():
         },
         {"task_group_id": "foo_id"},
         {"queue_name": "foo_name"},
+        {
+            "payload": "abc",
+            "details": {
+                "Blah_Version": "3.10.4",
+                "Blah number": 1234,
+            },
+        },
+        {
+            "payload": "something",
+        },
     ],
 )
 def test_redis_task_create(redis_client, add_kwargs):
@@ -71,6 +81,12 @@ def test_redis_task_create(redis_client, add_kwargs):
         "queue_name",
     ]:
         assert getattr(task, attrname) == add_kwargs.get(attrname)
+
+    if "details" in add_kwargs:
+        for k, v in add_kwargs["details"].items():
+            assert task.details[k] == v
+    else:
+        assert task.details is None
 
 
 def test_redis_task_cannot_increase_ttl(redis_client):

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,6 @@ skip_install = true
 deps = twine
        build
 # clean the build dir before rebuilding
-whitelist_externals = rm
 allowlist_externals = rm
 commands_pre = rm -rf dist/
 commands =


### PR DESCRIPTION
This adds a field called 'details' to the Result class/Redis class that should contain metadata about the task ie. python version, sdk version etc. 

The old Result is renamed to ResultV1 for back compatibility testing.

This was already pushed to pypi and tested via new SDK and web-service PRs.

See story https://app.shortcut.com/funcx/story/25606/report-warning-error-message-if-sdk-and-worker-python-version-mismatch