### PR TITLE
Reorder pyupgrade in pre commit conf

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,12 @@ repos:
   hooks:
     - id: check-dependabot
     - id: check-github-workflows
-- repo: https://github.com/psf/black
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.15.0
+  hooks:
+    - id: pyupgrade
+      args: ["--py37-plus"]
+- repo: https://github.com/psf/black-pre-commit-mirror
   rev: 23.10.1
   hooks:
     - id: black
@@ -22,11 +27,6 @@ repos:
   rev: 5.12.0
   hooks:
     - id: isort
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.15.0
-  hooks:
-    - id: pyupgrade
-      args: ["--py36-plus"]
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.6.1
   hooks:


### PR DESCRIPTION
Because PyUpgrade may make changes, it's possible that it would cause black to iterate again.  Avoid double-duty commit munging by having PyUpgrade act first.