### PR TITLE
bump version out of alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 <!-- scriv-insert-here -->
 
-<a id='changelog-0.3.0a1'></a>
-## 0.3.0a1 (2023-08-07)
+<a id='changelog-0.3.0'></a>
+## 0.3.0 (2023-08-07)
 
 ### Changed
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = globus-compute-common
-version = 0.3.0a2
+version = 0.3.0
 description = Common tools for Globus Compute projects
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
No functionality change.

Remove the alpha postfix to take -common out of alpha in preparation for release.