### PR TITLE
Fix `UserWarning`s from pydantic V2

### DIFF
--- a/src/globus_compute_common/messagepack/message_types/base.py
+++ b/src/globus_compute_common/messagepack/message_types/base.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import pydantic
 import typing as t
 
+import pydantic
 from pydantic import BaseModel
 
 from ..exceptions import WrongMessageTypeError

--- a/src/globus_compute_common/messagepack/message_types/base.py
+++ b/src/globus_compute_common/messagepack/message_types/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pydantic
 import typing as t
 
 from pydantic import BaseModel
@@ -22,12 +23,17 @@ class Message(BaseModel):
 
     # common Config for all of our pydantic models
     class Config:
-        # set this flag to allow underscore-prefixed attrs to be used rather than
-        # pydantic.PrivateAttr to declare instance variables on models which are
-        # not part of the serialized data
-        # see:
-        #   https://pydantic-docs.helpmanual.io/usage/models/#private-model-attributes
-        underscore_attrs_are_private = True
+        version = [int(num) for num in pydantic.__version__.split(".")]
+        major_version = version[0]
+        if major_version < 2:
+            # Set this flag if using Pydantic V2 to allow underscore-prefixed attrs
+            # to be used rather than pydantic.PrivateAttr to declare instance variables
+            # on models which are not part of the serialized data.
+            #
+            # See the following links:
+            # - attr: https://pydantic-docs.helpmanual.io/usage/models/#private-model-attributes
+            # - V2 migration: https://docs.pydantic.dev/latest/migration/#removed-in-pydantic-v2
+            underscore_attrs_are_private = True
 
     def assert_one_of_types(self, *message_types: type[Message]) -> None:
         if not isinstance(self, message_types):

--- a/src/globus_compute_common/messagepack/message_types/ep_status_report.py
+++ b/src/globus_compute_common/messagepack/message_types/ep_status_report.py
@@ -1,3 +1,4 @@
+import pydantic
 import typing as t
 import uuid
 
@@ -20,4 +21,12 @@ class EPStatusReport(Message):
     task_statuses: t.Dict[str, t.List[TaskTransition]]
 
     class Config:
-        allow_population_by_field_name = True
+        version = [int(num) for num in pydantic.__version__.split(".")]
+        major_version = version[0]
+        if major_version == 2:
+            # In Pydantic V2, `allow_population_by_field_name` was renamed to
+            # `populate_by_name`, see:
+            # https://docs.pydantic.dev/latest/migration/#changes-to-config
+            populate_by_name = True
+        else:
+            allow_population_by_field_name = True

--- a/src/globus_compute_common/messagepack/message_types/ep_status_report.py
+++ b/src/globus_compute_common/messagepack/message_types/ep_status_report.py
@@ -1,7 +1,7 @@
-import pydantic
 import typing as t
 import uuid
 
+import pydantic
 from pydantic import Field
 
 from .base import Message, meta


### PR DESCRIPTION
## Context
For a project I'm working on, I am relying on the latest version of ProxyStore which uses V2 of `pydantic`. As a result, `globus_compute_common` raises UserWarnings because it is assuming V1 of `pydantic` is installed. Thus, it is setting two attrs that have since been renamed or removed entirely from V2 of `pydantic`.

<img width="1220" alt="Screenshot 2024-03-07 at 3 37 52 PM" src="https://github.com/funcx-faas/funcx-common/assets/5210444/b4e9576a-8b56-442d-ace9-239240774a46">

## What's been changed
This minimally changed two files that are the source of the raised `UserWarning` instances. My fix just checks the version of `pydantic` the user has installed. If the user's version is V2, then the fix removes the attr that `pydantic` no long supports and renames the attr that has been renamed.