### PR TITLE
Support pydantic v2

### DIFF
--- a/changelog.d/20240322_121115_30907815+rjmello_pydantic_v2_support_sc_26075.md
+++ b/changelog.d/20240322_121115_30907815+rjmello_pydantic_v2_support_sc_26075.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added support for Pydantic v2.

--- a/src/globus_compute_common/messagepack/message_types/base.py
+++ b/src/globus_compute_common/messagepack/message_types/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-from pydantic import BaseModel
+from globus_compute_common.pydantic_v1 import BaseModel
 
 from ..exceptions import WrongMessageTypeError
 

--- a/src/globus_compute_common/messagepack/message_types/ep_status_report.py
+++ b/src/globus_compute_common/messagepack/message_types/ep_status_report.py
@@ -1,7 +1,7 @@
 import typing as t
 import uuid
 
-from pydantic import Field
+from globus_compute_common.pydantic_v1 import Field
 
 from .base import Message, meta
 from .task_transition import TaskTransition

--- a/src/globus_compute_common/messagepack/message_types/result.py
+++ b/src/globus_compute_common/messagepack/message_types/result.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import typing as t
 import uuid
 
-import pydantic
+from globus_compute_common import pydantic_v1
 
 from .base import Message, meta
 from .task_transition import TaskTransition
 
 
-class ResultErrorDetails(pydantic.BaseModel):
+class ResultErrorDetails(pydantic_v1.BaseModel):
     # a string for the error code
     code: str
     # the user is always supposed to see user_message somewhere

--- a/src/globus_compute_common/messagepack/protocol_versions/proto1.py
+++ b/src/globus_compute_common/messagepack/protocol_versions/proto1.py
@@ -47,7 +47,7 @@ import json
 import logging
 import typing as t
 
-import pydantic
+from globus_compute_common import pydantic_v1
 
 from ..message_types import ALL_MESSAGE_CLASSES, Message
 from ..protocol import MessagePackProtocol
@@ -63,11 +63,11 @@ _MESSAGE_TYPE_MAP: dict[str, type[Message]] = {
 }
 
 
-class MessageEnvelope(pydantic.BaseModel):
+class MessageEnvelope(pydantic_v1.BaseModel):
     message_type: str
     data: t.Dict[str, t.Any]
 
-    @pydantic.validator("message_type")
+    @pydantic_v1.validator("message_type")
     def message_type_is_known(cls, v: str) -> str:
         if v not in _MESSAGE_TYPE_MAP:
             # pydantic will wrap this message + context in a ValidationError
@@ -88,7 +88,7 @@ def _log_unknown_fields(model: type[_ModelT], data: dict[str, t.Any]) -> None:
     else:
         raise NotImplementedError
 
-    model_ = t.cast(pydantic.BaseModel, model)
+    model_ = t.cast(pydantic_v1.BaseModel, model)
 
     unknown_fields = set(data)
     for name, field in model_.__fields__.items():
@@ -105,7 +105,7 @@ def _log_unknown_fields(model: type[_ModelT], data: dict[str, t.Any]) -> None:
 
 
 def _load(model: type[_ModelT], data: dict[str, t.Any]) -> _ModelT:
-    model_ = t.cast("type[pydantic.BaseModel]", model)
+    model_ = t.cast("type[pydantic_v1.BaseModel]", model)
     ret = model_.parse_obj(data)
     _log_unknown_fields(model, data)
     return t.cast(_ModelT, ret)

--- a/src/globus_compute_common/pydantic_v1.py
+++ b/src/globus_compute_common/pydantic_v1.py
@@ -1,0 +1,8 @@
+"""Pydantic v2 provides access to the v1 API, enabling us to
+continue using v1 while allowing users to install v2 as needed.
+"""
+
+try:
+    from pydantic.v1 import *  # noqa: F401 F403
+except ImportError:
+    from pydantic import *  # noqa: F401 F403

--- a/tests/unit/test_messagepack.py
+++ b/tests/unit/test_messagepack.py
@@ -3,9 +3,9 @@ import logging
 import typing as t
 import uuid
 
-import pydantic
 import pytest
 
+from globus_compute_common import pydantic_v1
 from globus_compute_common.messagepack import (
     MessagePacker,
     UnrecognizedProtocolVersion,
@@ -392,7 +392,7 @@ def _required_arg_test_ids(param):
     ids=_required_arg_test_ids,
 )
 def test_message_missing_required_fields(message_class, init_args):
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(pydantic_v1.ValidationError):
         message_class(**init_args)
 
 
@@ -416,7 +416,7 @@ def test_result_is_error(details, expect):
 
 def test_invalid_uuid_rejected_on_init():
     Task(task_id=ID_ZERO, container_id=ID_ZERO, task_buffer="foo")
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(pydantic_v1.ValidationError):
         Task(task_id="foo", container_id=ID_ZERO, task_buffer="foo")
 
 
@@ -443,31 +443,31 @@ def test_invalid_uuid_rejected_on_unpack():
             },
         }
     )
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(pydantic_v1.ValidationError):
         unpack(buf_invalid)
 
 
 def test_cannot_unpack_unknown_message_type():
     buf = crudely_pack_data({"message_type": "foo", "data": {}})
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(pydantic_v1.ValidationError):
         unpack(buf)
 
 
 def test_cannot_unpack_message_missing_data():
     buf = crudely_pack_data({"message_type": "task"})
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(pydantic_v1.ValidationError):
         unpack(buf)
 
 
 def test_cannot_unpack_message_missing_type():
     buf = crudely_pack_data({"data": {}})
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(pydantic_v1.ValidationError):
         unpack(buf)
 
 
 def test_cannot_unpack_message_empty_data():
     buf = crudely_pack_data({"message_type": "task", "data": {}})
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(pydantic_v1.ValidationError):
         unpack(buf)
 
 
@@ -481,7 +481,7 @@ def test_cannot_unpack_message_empty_data():
 )
 def test_cannot_unpack_message_wrong_type(payload, expect_err):
     buf = crudely_pack_data(payload)
-    with pytest.raises(pydantic.ValidationError) as excinfo:
+    with pytest.raises(pydantic_v1.ValidationError) as excinfo:
         unpack(buf)
     assert expect_err in str(excinfo.value)
 


### PR DESCRIPTION
Pydantic v2 provides access to the v1 API, enabling us to continue using v1 while allowing users to install v2 as needed.