### PR TITLE
Enable Pydantic V2 support in setup.cfg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,4 +32,4 @@ repos:
   hooks:
     - id: mypy
       files: ^src/globus_compute_common/
-      additional_dependencies: ['types-redis', 'pydantic>=1,<2']
+      additional_dependencies: ['types-redis', 'pydantic>=1,<3']

--- a/changelog.d/20240327_225924_30907815+rjmello_HEAD.md
+++ b/changelog.d/20240327_225924_30907815+rjmello_HEAD.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Users can install Pydantic V2 without causing pip dependency errors.
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
 [options]
 python_requires = >=3.7
 install_requires =
-    pydantic>=1,<2
+    pydantic>=1,<3
 include_package_data = true
 package_dir=
     =src

--- a/src/globus_compute_common/pydantic_v1.py
+++ b/src/globus_compute_common/pydantic_v1.py
@@ -1,8 +1,8 @@
-"""Pydantic v2 provides access to the v1 API, enabling us to
-continue using v1 while allowing users to install v2 as needed.
+"""Pydantic V2 provides access to the V1 API, enabling us to
+continue using V1 while also supporting V2.
 """
 
 try:
     from pydantic.v1 import *  # noqa: F401 F403
 except ImportError:
-    from pydantic import *  # noqa: F401 F403
+    from pydantic import *  # type: ignore # noqa: F401 F403


### PR DESCRIPTION
We previously enabled support for Pydantic V2 but defaulted to installing V1 in `setup.cfg`, which could cause dependency conflicts with consuming packages. To address this, we have decided to extend the version range in `setup.cfg` to include V2.