### PR TITLE
Upgrade minimum Python version to 3.9

### DIFF
--- a/changelog.d/20250606_083513_kevin_upgrade_minimum_python.md
+++ b/changelog.d/20250606_083513_kevin_upgrade_minimum_python.md
@@ -1,0 +1,7 @@
+### Removed
+
+- Update minimum Python requirements to 3.9
+
+### Changed
+
+- Update minimum Redis and Boto requirements (now 5.3 and 1.37)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = globus-compute-common
-version = 0.6.0
+version = 0.7.0
 description = Common tools for Globus Compute projects
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -15,7 +15,7 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.9
 install_requires =
     pydantic>=1,<3
 include_package_data = true
@@ -37,8 +37,8 @@ dev =
     types-redis
 moto =
     moto[s3]<6
-redis = redis>=3.5.3,<6
-boto3 = boto3>=1.19.0
+redis = redis>=5.3,<7
+boto3 = boto3>=1.37
 
 [scriv]
 format = md


### PR DESCRIPTION
- Python 3.8 is EOL as of 2024 Oct 07

- Upgrade minimum required Redis and Boto

  - At this point, these are vestigial, but until we take the proper time to remove them, keep marching the versions so as not to hold up other infrastructure.