### PR TITLE
Move precommit to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,20 +13,18 @@ repos:
   rev: v3.21.2
   hooks:
     - id: pyupgrade
-      args: ["--py37-plus"]
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 26.5.1
+      args: ["--py310-plus"]
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.15.20
   hooks:
-    - id: black
-- repo: https://github.com/pycqa/flake8
-  rev: 7.3.0
-  hooks:
-    - id: flake8
-      additional_dependencies: ['flake8-bugbear==22.12.6']
-- repo: https://github.com/PyCQA/isort
-  rev: 9.0.0a3
-  hooks:
-    - id: isort
+    - id: ruff-check
+      types_or: [ python ]
+      args: [ --select, I ]
+    - id: ruff-check
+      types_or: [ python ]
+      args: [ --fix, --select, I ]
+    - id: ruff-format
+      types_or: [ python ]
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v2.1.0
   hooks:

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,4 +1,3 @@
-import sys
 import uuid
 
 import pytest
@@ -13,12 +12,7 @@ from globus_compute_common.tasks import TaskProtocol, TaskState
 
 try:
     import boto3
-
-    if sys.version_info >= (3, 8):
-        from moto import mock_aws as moto_mock
-    else:
-        # moto v5 doesn't support py37; fall back to v4 with mock_s3
-        from moto import mock_s3 as moto_mock
+    from moto import mock_aws as moto_mock
 
     has_boto = True
 except ImportError:


### PR DESCRIPTION
Like with https://github.com/globus/globus-compute/pull/2110, PRs are currently dying from pre-commit issues. Ruff is treating us well there, so also move to ruff here. (And also like the other PR, this updates our pyupgrade config to 310 at minimum.)

Ruff ran without any formatting changes; the only other change in this commit beside pre-commit config is a pyupgrade change in test_storage.