### PR TITLE
Rewrite `TaskProtocol` for structural typing

### DIFF
--- a/changelog.d/20260706_203941_chris_real_protocols.md
+++ b/changelog.d/20260706_203941_chris_real_protocols.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Converted `TaskProtocol` to a true `typing.Protocol` and updated task
+  implementations to rely on structural typing instead of inheriting
+  from a class which was a protocol in name only.

--- a/src/globus_compute_common/redis_task.py
+++ b/src/globus_compute_common/redis_task.py
@@ -8,7 +8,7 @@ from .redis import (
     HasRedisFieldsMeta,
     RedisField,
 )
-from .tasks import InternalTaskState, TaskProtocol, TaskState
+from .tasks import InternalTaskState, TaskState
 
 try:
     import redis
@@ -18,7 +18,7 @@ except ImportError:
     has_redis = False
 
 
-class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
+class RedisTask(metaclass=HasRedisFieldsMeta):
     """
     ORM-esque class to wrap access to properties of tasks.
 

--- a/src/globus_compute_common/tasks/protocol.py
+++ b/src/globus_compute_common/tasks/protocol.py
@@ -3,13 +3,7 @@ import typing as t
 from .constants import TaskState
 
 
-# use of typing.Protocol requires python3.8
-# since some parts of funcX support current pythons (py3.6, py3.8), we'll
-# define the protocol as a normal class for simplicity for now
-#
-# TODO: evaluate conditional requirement for typing_extensions to allow the use
-# of typing.Protocol
-class TaskProtocol:
+class TaskProtocol(t.Protocol):
     task_id: str
     endpoint: t.Optional[str]
     status: TaskState

--- a/tests/functional/redis/test_pubsub.py
+++ b/tests/functional/redis/test_pubsub.py
@@ -4,11 +4,11 @@ import uuid
 import pytest
 
 from globus_compute_common.redis import ComputeRedisPubSub
-from globus_compute_common.tasks import TaskProtocol, TaskState
+from globus_compute_common.tasks import TaskState
 from globus_compute_common.testing import LOCAL_REDIS_REACHABLE
 
 
-class SimpleInMemoryTask(TaskProtocol):
+class SimpleInMemoryTask:
     def __init__(self):
         self.task_id = str(uuid.uuid1())
         self.endpoint = None

--- a/tests/functional/redis/test_task_queue.py
+++ b/tests/functional/redis/test_task_queue.py
@@ -4,7 +4,7 @@ import uuid
 import pytest
 
 from globus_compute_common.redis import ComputeEndpointTaskQueue
-from globus_compute_common.tasks import TaskProtocol, TaskState
+from globus_compute_common.tasks import TaskState
 from globus_compute_common.testing import LOCAL_REDIS_REACHABLE
 
 
@@ -12,7 +12,7 @@ from globus_compute_common.testing import LOCAL_REDIS_REACHABLE
     not LOCAL_REDIS_REACHABLE, reason="test requires local redis reachable"
 )
 def test_enqueue_and_dequeue_simple_task():
-    class SimpleInMemoryTask(TaskProtocol):
+    class SimpleInMemoryTask:
         def __init__(self):
             self.task_id = str(uuid.uuid1())
             self.endpoint = None

--- a/tests/functional/storage/test_implicit_redis.py
+++ b/tests/functional/storage/test_implicit_redis.py
@@ -1,10 +1,10 @@
 import uuid
 
 from globus_compute_common.task_storage import ImplicitRedisStorage
-from globus_compute_common.tasks import TaskProtocol, TaskState
+from globus_compute_common.tasks import TaskState
 
 
-class SimpleInMemoryTask(TaskProtocol):
+class SimpleInMemoryTask:
     def __init__(self):
         self.task_id = str(uuid.uuid1())
         self.endpoint = None

--- a/tests/functional/storage/test_s3_functional.py
+++ b/tests/functional/storage/test_s3_functional.py
@@ -3,7 +3,7 @@ import uuid
 import pytest
 
 from globus_compute_common.task_storage import RedisS3Storage, StorageException
-from globus_compute_common.tasks import TaskProtocol, TaskState
+from globus_compute_common.tasks import TaskState
 
 try:
     import boto3
@@ -20,7 +20,7 @@ def _requires_s3_bucket(compute_s3_bucket):
         pytest.skip("test requires --compute-s3-bucket")
 
 
-class SimpleInMemoryTask(TaskProtocol):
+class SimpleInMemoryTask:
     def __init__(self):
         self.task_id = str(uuid.uuid1())
         self.endpoint = None

--- a/tests/unit/test_redis_connection.py
+++ b/tests/unit/test_redis_connection.py
@@ -9,7 +9,7 @@ from globus_compute_common.redis import (
     default_redis_connection_factory,
     redis_connection_error_logging,
 )
-from globus_compute_common.tasks import TaskProtocol, TaskState
+from globus_compute_common.tasks import TaskState
 
 try:
     import redis
@@ -41,7 +41,7 @@ def test_pubsub_repr():
 
 @pytest.mark.skipif(not has_redis, reason="test requires redis lib")
 def test_connection_error_on_enqueue(monkeypatch):
-    class SimpleInMemoryTask(TaskProtocol):
+    class SimpleInMemoryTask:
         def __init__(self):
             self.task_id = str(uuid.uuid1())
             self.endpoint = None

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -8,7 +8,7 @@ from globus_compute_common.task_storage import (
     StorageException,
     get_default_task_storage,
 )
-from globus_compute_common.tasks import TaskProtocol, TaskState
+from globus_compute_common.tasks import TaskState
 
 try:
     import boto3
@@ -19,7 +19,7 @@ except ImportError:
     has_boto = False
 
 
-class SimpleInMemoryTask(TaskProtocol):
+class SimpleInMemoryTask:
     def __init__(self):
         self.task_id = str(uuid.uuid1())
         self.endpoint = None


### PR DESCRIPTION
Removes and implements an old TODO, which will be useful for later work in our services repository.